### PR TITLE
perf(libvroom): Add compact() call for O(1) field access

### DIFF
--- a/src/libvroom/include/extraction_config.h
+++ b/src/libvroom/include/extraction_config.h
@@ -4,9 +4,12 @@
 #include "common_defs.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace libvroom {
@@ -74,6 +77,291 @@ struct ExtractionConfig {
   size_t max_integer_digits = 20;
 
   static ExtractionConfig defaults() { return ExtractionConfig{}; }
+};
+
+/**
+ * Data type hints for per-column type configuration.
+ *
+ * When set, the parser will attempt to interpret the column as this type,
+ * bypassing automatic type inference. Use TypeHint::AUTO to allow
+ * automatic type detection for a column.
+ */
+enum class TypeHint : uint8_t {
+  AUTO = 0, ///< Automatic type detection (default)
+  BOOLEAN,  ///< Force interpretation as boolean
+  INTEGER,  ///< Force interpretation as integer
+  DOUBLE,   ///< Force interpretation as double/float
+  STRING,   ///< Force interpretation as string (no conversion)
+  DATE,     ///< Force interpretation as date
+  DATETIME, ///< Force interpretation as datetime/timestamp
+  SKIP      ///< Skip this column during extraction
+};
+
+/**
+ * Convert a TypeHint enum to its string representation.
+ */
+inline const char* type_hint_to_string(TypeHint hint) {
+  switch (hint) {
+  case TypeHint::AUTO:
+    return "auto";
+  case TypeHint::BOOLEAN:
+    return "boolean";
+  case TypeHint::INTEGER:
+    return "integer";
+  case TypeHint::DOUBLE:
+    return "double";
+  case TypeHint::STRING:
+    return "string";
+  case TypeHint::DATE:
+    return "date";
+  case TypeHint::DATETIME:
+    return "datetime";
+  case TypeHint::SKIP:
+    return "skip";
+  }
+  return "unknown";
+}
+
+/**
+ * Per-column configuration for value extraction.
+ *
+ * ColumnConfig allows specifying extraction settings on a per-column basis,
+ * overriding the global ExtractionConfig for specific columns. This is useful
+ * for CSVs with mixed formats, such as:
+ * - Different decimal separators in different columns
+ * - Column-specific NA value definitions
+ * - Forcing specific type interpretations
+ *
+ * Fields use std::optional to enable selective overrides: when a field is
+ * nullopt, the global ExtractionConfig value is used instead.
+ *
+ * @example
+ * @code
+ * // Create per-column config for a price column with European decimal format
+ * ColumnConfig price_config;
+ * price_config.type_hint = TypeHint::DOUBLE;
+ * price_config.na_values = {"", "N/A", "-"};
+ *
+ * // Apply to specific column by index
+ * ColumnConfigMap configs;
+ * configs.set(2, price_config);  // Column index 2
+ *
+ * // Or by column name (requires header)
+ * configs.set("price", price_config);
+ * @endcode
+ *
+ * @see ExtractionConfig for global configuration options
+ * @see ColumnConfigMap for managing per-column configurations
+ */
+struct ColumnConfig {
+  /// Type hint to override automatic type detection.
+  /// When set, the extractor will attempt to interpret values as this type.
+  std::optional<TypeHint> type_hint = std::nullopt;
+
+  /// Column-specific NA values (overrides ExtractionConfig::na_values).
+  /// When set, only these values are recognized as NA for this column.
+  std::optional<std::vector<std::string_view>> na_values = std::nullopt;
+
+  /// Column-specific true values for boolean parsing.
+  std::optional<std::vector<std::string_view>> true_values = std::nullopt;
+
+  /// Column-specific false values for boolean parsing.
+  std::optional<std::vector<std::string_view>> false_values = std::nullopt;
+
+  /// Column-specific whitespace trimming behavior.
+  std::optional<bool> trim_whitespace = std::nullopt;
+
+  /// Column-specific leading zeros handling for integers.
+  std::optional<bool> allow_leading_zeros = std::nullopt;
+
+  /// Column-specific maximum integer digits.
+  std::optional<size_t> max_integer_digits = std::nullopt;
+
+  /**
+   * Merge this column config with a global ExtractionConfig.
+   * Returns an ExtractionConfig with this column's overrides applied.
+   */
+  ExtractionConfig merge_with(const ExtractionConfig& global) const {
+    ExtractionConfig result = global;
+    if (na_values.has_value()) {
+      result.na_values = *na_values;
+    }
+    if (true_values.has_value()) {
+      result.true_values = *true_values;
+    }
+    if (false_values.has_value()) {
+      result.false_values = *false_values;
+    }
+    if (trim_whitespace.has_value()) {
+      result.trim_whitespace = *trim_whitespace;
+    }
+    if (allow_leading_zeros.has_value()) {
+      result.allow_leading_zeros = *allow_leading_zeros;
+    }
+    if (max_integer_digits.has_value()) {
+      result.max_integer_digits = *max_integer_digits;
+    }
+    return result;
+  }
+
+  /**
+   * Check if this config has any overrides set.
+   */
+  bool has_overrides() const {
+    return type_hint.has_value() || na_values.has_value() || true_values.has_value() ||
+           false_values.has_value() || trim_whitespace.has_value() ||
+           allow_leading_zeros.has_value() || max_integer_digits.has_value();
+  }
+
+  /// Factory for default config (no overrides).
+  static ColumnConfig defaults() { return ColumnConfig{}; }
+
+  /// Factory for string-only column (skip type conversion).
+  static ColumnConfig as_string() {
+    ColumnConfig config;
+    config.type_hint = TypeHint::STRING;
+    return config;
+  }
+
+  /// Factory for integer column.
+  static ColumnConfig as_integer() {
+    ColumnConfig config;
+    config.type_hint = TypeHint::INTEGER;
+    return config;
+  }
+
+  /// Factory for double/float column.
+  static ColumnConfig as_double() {
+    ColumnConfig config;
+    config.type_hint = TypeHint::DOUBLE;
+    return config;
+  }
+
+  /// Factory for boolean column.
+  static ColumnConfig as_boolean() {
+    ColumnConfig config;
+    config.type_hint = TypeHint::BOOLEAN;
+    return config;
+  }
+
+  /// Factory for skipped column.
+  static ColumnConfig skip() {
+    ColumnConfig config;
+    config.type_hint = TypeHint::SKIP;
+    return config;
+  }
+};
+
+/**
+ * Container for managing per-column configurations.
+ *
+ * ColumnConfigMap allows setting configuration overrides for specific columns,
+ * either by index (0-based) or by column name (requires header row). Columns
+ * without explicit configuration use the global ExtractionConfig.
+ *
+ * @example
+ * @code
+ * ColumnConfigMap configs;
+ *
+ * // Set by index (works without header)
+ * configs.set(0, ColumnConfig::as_string());   // First column as string
+ * configs.set(2, ColumnConfig::as_double());   // Third column as double
+ *
+ * // Set by name (resolved at extraction time, requires header)
+ * configs.set("id", ColumnConfig::as_integer());
+ * configs.set("price", ColumnConfig::as_double());
+ *
+ * // Get config for a column (returns nullptr if no override)
+ * const ColumnConfig* config = configs.get(2);
+ * if (config && config->type_hint == TypeHint::DOUBLE) {
+ *     // Parse as double
+ * }
+ * @endcode
+ *
+ * @see ColumnConfig for available configuration options
+ * @see ValueExtractor for using column configs during extraction
+ */
+class ColumnConfigMap {
+public:
+  ColumnConfigMap() = default;
+
+  /**
+   * Set configuration for a column by index.
+   * @param col_index 0-based column index
+   * @param config Configuration to apply to this column
+   */
+  void set(size_t col_index, const ColumnConfig& config) { by_index_[col_index] = config; }
+
+  /**
+   * Set configuration for a column by name.
+   * Column names are resolved when the ValueExtractor is initialized with headers.
+   * @param col_name Column name (case-sensitive, must match header exactly)
+   * @param config Configuration to apply to this column
+   */
+  void set(const std::string& col_name, const ColumnConfig& config) { by_name_[col_name] = config; }
+
+  /**
+   * Get configuration for a column by index.
+   * @param col_index 0-based column index
+   * @return Pointer to column config, or nullptr if no override is set
+   */
+  const ColumnConfig* get(size_t col_index) const {
+    auto it = by_index_.find(col_index);
+    return it != by_index_.end() ? &it->second : nullptr;
+  }
+
+  /**
+   * Get configuration for a column by name.
+   * @param col_name Column name
+   * @return Pointer to column config, or nullptr if no override is set
+   */
+  const ColumnConfig* get(const std::string& col_name) const {
+    auto it = by_name_.find(col_name);
+    return it != by_name_.end() ? &it->second : nullptr;
+  }
+
+  /**
+   * Check if any column configurations are set.
+   */
+  bool empty() const { return by_index_.empty() && by_name_.empty(); }
+
+  /**
+   * Clear all column configurations.
+   */
+  void clear() {
+    by_index_.clear();
+    by_name_.clear();
+  }
+
+  /**
+   * Get all configurations by index.
+   */
+  const std::unordered_map<size_t, ColumnConfig>& by_index() const { return by_index_; }
+
+  /**
+   * Get all configurations by name.
+   */
+  const std::unordered_map<std::string, ColumnConfig>& by_name() const { return by_name_; }
+
+  /**
+   * Resolve name-based configurations to indices using a column name map.
+   * After calling this, all by-name configs are converted to by-index configs.
+   * @param name_to_index Map from column name to index
+   */
+  void resolve_names(const std::unordered_map<std::string, size_t>& name_to_index) {
+    for (const auto& [name, config] : by_name_) {
+      auto it = name_to_index.find(name);
+      if (it != name_to_index.end()) {
+        // Name-based config takes precedence if there's a conflict
+        by_index_[it->second] = config;
+      }
+    }
+    // Keep by_name_ around for reference, but by_index_ now has all resolved configs
+  }
+
+private:
+  std::unordered_map<size_t, ColumnConfig> by_index_;
+  std::unordered_map<std::string, ColumnConfig> by_name_;
 };
 
 /**

--- a/src/libvroom/include/value_extraction.h
+++ b/src/libvroom/include/value_extraction.h
@@ -4,12 +4,15 @@
 #include "common_defs.h"
 #include "dialect.h"
 #include "extraction_config.h"
+#include "two_pass.h"
 
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -19,7 +22,347 @@
 
 namespace libvroom {
 
-class ParseIndex;
+// Forward declarations
+class ValueExtractor;
+class LazyColumnIterator;
+
+/**
+ * @brief Lazy column accessor for ALTREP-style deferred field parsing.
+ *
+ * LazyColumn provides per-column lazy access to CSV data without loading
+ * or parsing the entire file upfront. This enables R's ALTREP pattern
+ * where columns are only parsed when accessed.
+ *
+ * Key features:
+ * - **Random access**: O(n_threads) access to any row via operator[]
+ * - **Byte range access**: get_bounds() returns raw byte ranges for deferred parsing
+ * - **Iterator support**: Range-based for loops via begin()/end()
+ * - **Zero-copy views**: Returns string_view into the original buffer
+ *
+ * The class holds lightweight references to the buffer, index, and dialect.
+ * It does NOT copy or sort the index, making construction O(1).
+ *
+ * @note The underlying buffer and ParseIndex must remain valid for the lifetime
+ *       of the LazyColumn. This is typically managed by the Parser::Result object.
+ *
+ * @example
+ * @code
+ * // Create lazy column from parser result
+ * auto result = parser.parse(buf, len);
+ * LazyColumn col = result.get_column(0);
+ *
+ * // Random access - parses only row 100
+ * std::string_view value = col[100];
+ *
+ * // Get byte bounds for deferred parsing
+ * FieldSpan span = col.get_bounds(100);
+ * // Parse later: parse_integer<int64_t>(buf + span.start, span.length())
+ *
+ * // Iterate (parses each row on access)
+ * for (std::string_view row_value : col) {
+ *     process(row_value);
+ * }
+ * @endcode
+ *
+ * @see ValueExtractor for eager column extraction
+ * @see ParseIndex::get_field_span() for the underlying field lookup
+ */
+class LazyColumn {
+public:
+  /**
+   * @brief Construct a lazy column accessor with bounds validation.
+   *
+   * @param buf Pointer to the CSV data buffer
+   * @param len Length of the buffer in bytes
+   * @param idx Reference to the parsed index
+   * @param col Column index (0-based)
+   * @param has_header Whether the CSV has a header row (affects row indexing)
+   * @param dialect CSV dialect for quote handling
+   * @param config Extraction configuration for parsing
+   * @param validate_bounds If true (default), validates col < idx.columns
+   *
+   * @throws std::out_of_range if validate_bounds is true and col >= idx.columns
+   */
+  LazyColumn(const uint8_t* buf, size_t len, const ParseIndex& idx, size_t col, bool has_header,
+             const Dialect& dialect = Dialect::csv(),
+             const ExtractionConfig& config = ExtractionConfig::defaults(),
+             bool validate_bounds = true)
+      : buf_(buf), len_(len), idx_(&idx), col_(col), has_header_(has_header), dialect_(dialect),
+        config_(config) {
+    // Validate column bounds if requested
+    if (validate_bounds && col >= idx_->columns) {
+      throw std::out_of_range("LazyColumn: column index " + std::to_string(col) +
+                              " out of range (columns = " + std::to_string(idx_->columns) + ")");
+    }
+
+    // Compute number of rows
+    if (idx_->columns > 0) {
+      uint64_t total_fields = idx_->total_indexes();
+      uint64_t total_rows = total_fields / idx_->columns;
+      num_rows_ = has_header_ ? (total_rows > 0 ? total_rows - 1 : 0) : total_rows;
+    }
+  }
+
+  /**
+   * @brief Get the number of data rows in the column.
+   *
+   * @return Number of rows (excludes header if has_header is true)
+   */
+  size_t size() const { return num_rows_; }
+
+  /**
+   * @brief Check if the column is empty.
+   */
+  bool empty() const { return num_rows_ == 0; }
+
+  /**
+   * @brief Get the column index.
+   */
+  size_t column_index() const { return col_; }
+
+  /**
+   * @brief Random access to a row's string value.
+   *
+   * Returns a string_view into the original buffer. The view is valid as long
+   * as the underlying buffer remains valid. Quote characters are included in
+   * the returned view for quoted fields.
+   *
+   * @param row Row index (0-based, excludes header)
+   * @return String view of the field content
+   * @throws std::out_of_range if row >= size()
+   *
+   * @note Complexity: O(n_threads) due to ParseIndex::get_field_span()
+   */
+  std::string_view operator[](size_t row) const {
+    if (row >= num_rows_) {
+      throw std::out_of_range("LazyColumn: row index out of range");
+    }
+    FieldSpan span = get_bounds(row);
+    if (!span.is_valid()) {
+      return std::string_view();
+    }
+    return get_field_content(span);
+  }
+
+  /**
+   * @brief Get raw byte boundaries for a row.
+   *
+   * Returns the byte range in the source buffer for deferred parsing.
+   * This enables the ALTREP pattern where parsing happens only when
+   * the value is actually needed.
+   *
+   * @param row Row index (0-based, excludes header)
+   * @return FieldSpan with start/end byte positions, or invalid span if out of bounds
+   *
+   * @note Complexity: O(n_threads) due to ParseIndex::get_field_span()
+   *
+   * @example
+   * @code
+   * FieldSpan span = col.get_bounds(row);
+   * if (span.is_valid()) {
+   *     // Deferred parsing - only parse when value is needed
+   *     auto result = parse_integer<int64_t>(
+   *         reinterpret_cast<const char*>(buf + span.start),
+   *         span.length()
+   *     );
+   * }
+   * @endcode
+   */
+  FieldSpan get_bounds(size_t row) const {
+    // Adjust row for header
+    size_t actual_row = has_header_ ? row + 1 : row;
+    return idx_->get_field_span(actual_row, col_);
+  }
+
+  /**
+   * @brief Get a typed value from a row.
+   *
+   * Parses the field content to the requested type using the configured
+   * ExtractionConfig.
+   *
+   * @tparam T The type to extract (int32_t, int64_t, double, bool)
+   * @param row Row index (0-based, excludes header)
+   * @return ExtractResult containing the parsed value or error/NA status
+   * @throws std::out_of_range if row >= size()
+   */
+  template <typename T> ExtractResult<T> get(size_t row) const;
+
+  /**
+   * @brief Get string value with unescaping applied.
+   *
+   * Unlike operator[], this method handles escape sequences (e.g., doubled
+   * quotes) and returns a clean string. This involves a copy.
+   *
+   * @param row Row index (0-based, excludes header)
+   * @return Unescaped string content
+   * @throws std::out_of_range if row >= size()
+   */
+  std::string get_string(size_t row) const;
+
+  // Iterator support
+  class Iterator;
+  Iterator begin() const;
+  Iterator end() const;
+
+  /**
+   * @brief Iterator for lazy column traversal.
+   *
+   * Provides input iterator semantics for range-based for loops.
+   * Each dereference accesses the field via the ParseIndex, so
+   * iterating is O(n * n_threads) total.
+   */
+  class Iterator {
+  public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = std::string_view;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const std::string_view*;
+    using reference = std::string_view;
+
+    Iterator(const LazyColumn* col, size_t row) : col_(col), row_(row) {}
+
+    reference operator*() const { return (*col_)[row_]; }
+
+    Iterator& operator++() {
+      ++row_;
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator tmp = *this;
+      ++row_;
+      return tmp;
+    }
+
+    bool operator==(const Iterator& other) const { return row_ == other.row_; }
+
+    bool operator!=(const Iterator& other) const { return row_ != other.row_; }
+
+    size_t row() const { return row_; }
+
+  private:
+    const LazyColumn* col_;
+    size_t row_;
+  };
+
+  /**
+   * @brief Get the extraction configuration.
+   */
+  const ExtractionConfig& config() const { return config_; }
+
+  /**
+   * @brief Get the dialect.
+   */
+  const Dialect& dialect() const { return dialect_; }
+
+  /**
+   * @brief Check if the column has a header.
+   */
+  bool has_header() const { return has_header_; }
+
+private:
+  const uint8_t* buf_;
+  size_t len_;
+  const ParseIndex* idx_;
+  size_t col_;
+  bool has_header_;
+  Dialect dialect_;
+  ExtractionConfig config_;
+  size_t num_rows_ = 0;
+
+  /**
+   * @brief Extract field content from a span, handling quotes.
+   */
+  std::string_view get_field_content(const FieldSpan& span) const {
+    if (!span.is_valid() || span.start >= len_) {
+      return std::string_view();
+    }
+
+    size_t start = static_cast<size_t>(span.start);
+    size_t end = std::min(static_cast<size_t>(span.end), len_);
+
+    // Handle CR in CRLF endings
+    if (end > start && buf_[end - 1] == '\r') {
+      --end;
+    }
+
+    // Handle quoted fields - strip outer quotes
+    if (end > start && buf_[start] == static_cast<uint8_t>(dialect_.quote_char)) {
+      if (buf_[end - 1] == static_cast<uint8_t>(dialect_.quote_char)) {
+        ++start;
+        --end;
+      }
+    }
+
+    if (end < start) {
+      end = start;
+    }
+
+    return std::string_view(reinterpret_cast<const char*>(buf_ + start), end - start);
+  }
+};
+
+// LazyColumn iterator methods (defined after the class)
+inline LazyColumn::Iterator LazyColumn::begin() const {
+  return Iterator(this, 0);
+}
+
+inline LazyColumn::Iterator LazyColumn::end() const {
+  return Iterator(this, num_rows_);
+}
+
+/**
+ * @brief Factory function to create a LazyColumn from a ParseIndex with bounds validation.
+ *
+ * Validates that the column index is within bounds before construction,
+ * providing a clear error message if the column index is invalid.
+ *
+ * @param buf Pointer to the CSV data buffer
+ * @param len Length of the buffer
+ * @param idx Reference to the parsed index
+ * @param col Column index (0-based)
+ * @param has_header Whether the CSV has a header row
+ * @param dialect CSV dialect settings
+ * @param config Extraction configuration
+ * @return LazyColumn for the specified column
+ * @throws std::out_of_range if col >= idx.columns
+ *
+ * @see make_lazy_column_unchecked() for performance-critical scenarios where
+ *      bounds checking has already been performed
+ */
+inline LazyColumn make_lazy_column(const uint8_t* buf, size_t len, const ParseIndex& idx,
+                                   size_t col, bool has_header = true,
+                                   const Dialect& dialect = Dialect::csv(),
+                                   const ExtractionConfig& config = ExtractionConfig::defaults()) {
+  return LazyColumn(buf, len, idx, col, has_header, dialect, config, true);
+}
+
+/**
+ * @brief Factory function to create a LazyColumn without bounds validation.
+ *
+ * This variant skips column bounds validation for performance-critical scenarios
+ * where the caller has already validated the column index. Using an invalid
+ * column index results in undefined behavior (typically empty/invalid spans).
+ *
+ * @param buf Pointer to the CSV data buffer
+ * @param len Length of the buffer
+ * @param idx Reference to the parsed index
+ * @param col Column index (0-based)
+ * @param has_header Whether the CSV has a header row
+ * @param dialect CSV dialect settings
+ * @param config Extraction configuration
+ * @return LazyColumn for the specified column
+ *
+ * @note Only use this when you have already validated col < idx.columns
+ *
+ * @see make_lazy_column() for the validated version
+ */
+inline LazyColumn
+make_lazy_column_unchecked(const uint8_t* buf, size_t len, const ParseIndex& idx, size_t col,
+                           bool has_header = true, const Dialect& dialect = Dialect::csv(),
+                           const ExtractionConfig& config = ExtractionConfig::defaults()) {
+  return LazyColumn(buf, len, idx, col, has_header, dialect, config, false);
+}
 
 template <typename IntType>
 really_inline ExtractResult<IntType>
@@ -261,6 +604,61 @@ public:
                  const Dialect& dialect = Dialect::csv(),
                  const ExtractionConfig& config = ExtractionConfig::defaults());
 
+  /**
+   * Constructor with per-column configuration support.
+   *
+   * @param buf Pointer to the CSV data buffer
+   * @param len Length of the buffer
+   * @param idx Parsed index containing field positions
+   * @param dialect CSV dialect settings
+   * @param config Global extraction configuration (fallback for columns without overrides)
+   * @param column_configs Per-column configuration overrides
+   *
+   * @note Name-based column configs are resolved automatically after the header is read.
+   */
+  ValueExtractor(const uint8_t* buf, size_t len, const ParseIndex& idx, const Dialect& dialect,
+                 const ExtractionConfig& config, const ColumnConfigMap& column_configs);
+
+  /**
+   * Constructor with shared ParseIndex ownership for buffer lifetime safety.
+   *
+   * This constructor accepts a shared_ptr to a ParseIndex, enabling safe sharing
+   * of the underlying data between multiple consumers. The buffer data is obtained
+   * from the ParseIndex's shared buffer reference.
+   *
+   * Use this constructor when:
+   * - The ValueExtractor may outlive the original ParseIndex
+   * - Multiple consumers need concurrent access to the same parsed data
+   * - Implementing lazy column access (e.g., R's ALTREP)
+   *
+   * @param shared_idx Shared pointer to a ParseIndex with buffer set
+   * @param dialect CSV dialect settings
+   * @param config Global extraction configuration
+   *
+   * @throws std::invalid_argument if shared_idx is null or has no buffer
+   *
+   * @example
+   * @code
+   * // Parse and set up shared buffer
+   * auto buffer = std::make_shared<std::vector<uint8_t>>(data, data + len);
+   * auto result = parser.parse(buffer->data(), buffer->size());
+   * result.idx.set_buffer(buffer);
+   *
+   * // Create shared index and extractor
+   * auto shared_idx = result.idx.share();
+   * ValueExtractor extractor(shared_idx, dialect, config);
+   *
+   * // Original ParseIndex can be moved/destroyed safely
+   * result = {};  // Destroy original
+   *
+   * // Extractor still works - it holds shared references
+   * auto value = extractor.get<double>(0, 0);
+   * @endcode
+   */
+  ValueExtractor(std::shared_ptr<const ParseIndex> shared_idx,
+                 const Dialect& dialect = Dialect::csv(),
+                 const ExtractionConfig& config = ExtractionConfig::defaults());
+
   size_t num_rows() const { return num_rows_; }
   size_t num_columns() const { return num_columns_; }
   bool has_header() const { return has_header_; }
@@ -271,18 +669,74 @@ public:
     }
   }
 
+  // =========================================================================
+  // Buffer and Index accessors (for LazyColumn factory)
+  // =========================================================================
+
+  /**
+   * @brief Get the underlying data buffer pointer.
+   */
+  const uint8_t* buffer() const { return buf_; }
+
+  /**
+   * @brief Get the buffer length.
+   */
+  size_t buffer_length() const { return len_; }
+
+  /**
+   * @brief Get the parse index reference.
+   */
+  const ParseIndex& index() const { return idx(); }
+
+  /**
+   * @brief Get the dialect.
+   */
+  const Dialect& dialect() const { return dialect_; }
+
+  /**
+   * @brief Create a LazyColumn for the specified column.
+   *
+   * Factory method to create a LazyColumn that provides lazy per-row access
+   * to a single column. This is useful for R ALTREP integration where columns
+   * are only parsed when accessed.
+   *
+   * @param col Column index (0-based)
+   * @return LazyColumn for the specified column
+   * @throws std::out_of_range if col >= num_columns()
+   */
+  LazyColumn get_lazy_column(size_t col) const {
+    if (col >= num_columns_) {
+      throw std::out_of_range("Column index out of range");
+    }
+    return LazyColumn(buf_, len_, idx(), col, has_header_, dialect_, config_);
+  }
+
   std::string_view get_string_view(size_t row, size_t col) const;
   std::string get_string(size_t row, size_t col) const;
 
+  /**
+   * Get a typed value from a cell, using per-column config if available.
+   *
+   * This method checks for per-column configuration overrides and applies them
+   * when extracting and parsing the value. If no override exists for the column,
+   * the global config is used.
+   *
+   * @tparam T The type to extract (int32_t, int64_t, double, bool)
+   * @param row Row index (0-based, excludes header if has_header is true)
+   * @param col Column index (0-based)
+   * @return ExtractResult containing the parsed value or error/NA status
+   */
   template <typename T> ExtractResult<T> get(size_t row, size_t col) const {
     auto sv = get_string_view_internal(row, col);
+    const ExtractionConfig& effective_config = get_effective_config(col);
+
     // LCOV_EXCL_BR_START - if constexpr branches are compile-time only
     if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t>) {
-      return parse_integer_simd<T>(sv.data(), sv.size(), config_);
+      return parse_integer_simd<T>(sv.data(), sv.size(), effective_config);
     } else if constexpr (std::is_same_v<T, double>) {
-      return parse_double_simd(sv.data(), sv.size(), config_);
+      return parse_double_simd(sv.data(), sv.size(), effective_config);
     } else if constexpr (std::is_same_v<T, bool>) {
-      return parse_bool(sv.data(), sv.size(), config_);
+      return parse_bool(sv.data(), sv.size(), effective_config);
     } else {
       static_assert(!std::is_same_v<T, T>, "Unsupported type");
     }
@@ -313,26 +767,199 @@ public:
   const ExtractionConfig& config() const { return config_; }
   void set_config(const ExtractionConfig& config) { config_ = config; }
 
+  // =========================================================================
+  // Per-column configuration API
+  // =========================================================================
+
+  /**
+   * Get the column configuration map.
+   */
+  const ColumnConfigMap& column_configs() const { return column_configs_; }
+
+  /**
+   * Set the column configuration map.
+   * Name-based configs are resolved when headers are available.
+   */
+  void set_column_configs(const ColumnConfigMap& configs) {
+    column_configs_ = configs;
+    resolved_configs_.clear(); // Clear cache when configs change
+    resolve_column_configs();
+  }
+
+  /**
+   * Set configuration for a specific column by index.
+   * @param col_index 0-based column index
+   * @param config Configuration to apply
+   */
+  void set_column_config(size_t col_index, const ColumnConfig& config) {
+    column_configs_.set(col_index, config);
+    // Update resolved config cache for this column
+    if (config.has_overrides()) {
+      resolved_configs_[col_index] = config.merge_with(config_);
+    } else {
+      resolved_configs_.erase(col_index);
+    }
+  }
+
+  /**
+   * Set configuration for a specific column by name.
+   * The name is resolved to an index using the header row.
+   * @param col_name Column name (case-sensitive)
+   * @param config Configuration to apply
+   */
+  void set_column_config(const std::string& col_name, const ColumnConfig& config) {
+    column_configs_.set(col_name, config);
+    resolve_column_configs(); // Re-resolve to update the index
+  }
+
+  /**
+   * Get the per-column configuration for a specific column.
+   * @param col_index 0-based column index
+   * @return Pointer to column config, or nullptr if no override exists
+   */
+  const ColumnConfig* get_column_config(size_t col_index) const {
+    return column_configs_.get(col_index);
+  }
+
+  /**
+   * Get the type hint for a specific column.
+   * @param col_index 0-based column index
+   * @return The type hint, or TypeHint::AUTO if none is set
+   */
+  TypeHint get_type_hint(size_t col_index) const {
+    const ColumnConfig* config = column_configs_.get(col_index);
+    if (config && config->type_hint.has_value()) {
+      return *config->type_hint;
+    }
+    return TypeHint::AUTO;
+  }
+
+  /**
+   * Check if a column should be skipped during extraction.
+   * @param col_index 0-based column index
+   * @return true if the column has TypeHint::SKIP
+   */
+  bool should_skip_column(size_t col_index) const {
+    return get_type_hint(col_index) == TypeHint::SKIP;
+  }
+
+  /**
+   * @brief Result of a byte offset to (row, column) lookup.
+   *
+   * Location represents the result of finding which CSV cell contains
+   * a given byte offset. This enables efficient error reporting by
+   * converting internal byte positions to human-readable row/column
+   * coordinates.
+   */
+  struct Location {
+    size_t row;    ///< 0-based row index (data rows, header is row 0 if present)
+    size_t column; ///< 0-based column index
+    bool found;    ///< true if byte offset is within valid CSV data
+
+    /// @return true if the location is valid (found == true)
+    explicit operator bool() const { return found; }
+  };
+
+  /**
+   * @brief Convert a byte offset to (row, column) coordinates.
+   *
+   * Uses binary search on the internal index for O(log n) lookup instead of
+   * O(n) linear scan. This is useful for error reporting when you have a
+   * byte offset from parsing and need to display the location to users.
+   *
+   * The row number returned is 0-based and includes the header row (if present).
+   * So row 0 is the header (if has_header() is true), row 1 is the first data row.
+   * If has_header() is false, row 0 is the first data row.
+   *
+   * @param byte_offset Byte offset into the CSV buffer
+   * @return Location with row/column if found, or {0, 0, false} if offset is
+   *         out of range or no data exists
+   *
+   * @note Complexity: O(log n) where n is the number of fields in the CSV
+   *
+   * @example
+   * @code
+   * auto result = parser.parse(buf, len);
+   * ValueExtractor extractor(buf, len, result.idx);
+   *
+   * // Convert byte offset 150 to row/column
+   * auto loc = extractor.byte_offset_to_location(150);
+   * if (loc) {
+   *     std::cout << "Row " << loc.row << ", Column " << loc.column << std::endl;
+   * }
+   * @endcode
+   */
+  Location byte_offset_to_location(size_t byte_offset) const;
+
 private:
   const uint8_t* buf_;
   size_t len_;
-  const ParseIndex& idx_;
+  const ParseIndex* idx_ptr_; // Non-owning pointer (from reference constructor)
   Dialect dialect_;
   ExtractionConfig config_;
+  ColumnConfigMap column_configs_;
   size_t num_rows_ = 0;
   size_t num_columns_ = 0;
   bool has_header_ = true;
-  std::vector<uint64_t> linear_indexes_;
+
+  // Shared ownership members for buffer lifetime safety
+  std::shared_ptr<const ParseIndex> shared_idx_;              // Owns ParseIndex when shared
+  std::shared_ptr<const std::vector<uint8_t>> shared_buffer_; // Owns buffer when shared
+
+  // Cache of resolved configs (merged with global config) for fast lookup
+  mutable std::unordered_map<size_t, ExtractionConfig> resolved_configs_;
+
+  // Helper to get the ParseIndex (works for both ownership modes)
+  const ParseIndex& idx() const { return shared_idx_ ? *shared_idx_ : *idx_ptr_; }
 
   std::string_view get_string_view_internal(size_t row, size_t col) const;
   size_t compute_field_index(size_t row, size_t col) const;
   std::string unescape_field(std::string_view field) const;
-  void recalculate_num_rows() {
-    size_t total_indexes = linear_indexes_.size();
-    if (total_indexes > 0 && num_columns_ > 0) {
-      size_t total_rows = total_indexes / num_columns_;
-      num_rows_ = has_header_ ? (total_rows > 0 ? total_rows - 1 : 0) : total_rows;
+  void recalculate_num_rows();
+
+  /**
+   * Get the effective extraction config for a column.
+   * Returns the merged per-column config if one exists, otherwise the global config.
+   */
+  const ExtractionConfig& get_effective_config(size_t col) const {
+    // Check cache first
+    auto it = resolved_configs_.find(col);
+    if (it != resolved_configs_.end()) {
+      return it->second;
     }
+
+    // Check if there's a per-column config
+    const ColumnConfig* col_config = column_configs_.get(col);
+    if (col_config && col_config->has_overrides()) {
+      // Merge and cache
+      resolved_configs_[col] = col_config->merge_with(config_);
+      return resolved_configs_[col];
+    }
+
+    // No override, use global config
+    return config_;
+  }
+
+  /**
+   * Resolve name-based column configs to indices using header names.
+   */
+  void resolve_column_configs() {
+    if (!has_header_ || column_configs_.by_name().empty()) {
+      return;
+    }
+
+    // Build name-to-index map from headers
+    std::unordered_map<std::string, size_t> name_to_index;
+    auto headers = get_header();
+    for (size_t i = 0; i < headers.size(); ++i) {
+      name_to_index[headers[i]] = i;
+    }
+
+    // Resolve names to indices
+    column_configs_.resolve_names(name_to_index);
+
+    // Clear resolved config cache since indices may have changed
+    resolved_configs_.clear();
   }
 };
 
@@ -370,10 +997,102 @@ inline RowIterator end(const ValueExtractor& ve) {
   return RowIterator(&ve, ve.num_rows());
 }
 
+// LazyColumn::get<T>() implementation is defined after simd_number_parsing.h
+
 } // namespace libvroom
 
 // Include SIMD number parsing after all types are defined
 // This provides the implementations for parse_integer_simd and parse_double_simd
 #include "simd_number_parsing.h"
+
+// LazyColumn template method implementations (need SIMD parsers)
+namespace libvroom {
+
+template <typename T> ExtractResult<T> LazyColumn::get(size_t row) const {
+  if (row >= num_rows_) {
+    throw std::out_of_range("LazyColumn: row index out of range");
+  }
+
+  std::string_view sv = (*this)[row];
+
+  // LCOV_EXCL_BR_START - if constexpr branches are compile-time only
+  if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t>) {
+    return parse_integer_simd<T>(sv.data(), sv.size(), config_);
+  } else if constexpr (std::is_same_v<T, double>) {
+    return parse_double_simd(sv.data(), sv.size(), config_);
+  } else if constexpr (std::is_same_v<T, bool>) {
+    return parse_bool(sv.data(), sv.size(), config_);
+  } else {
+    static_assert(!std::is_same_v<T, T>, "Unsupported type");
+  }
+  // LCOV_EXCL_BR_STOP
+}
+
+inline std::string LazyColumn::get_string(size_t row) const {
+  if (row >= num_rows_) {
+    throw std::out_of_range("LazyColumn: row index out of range");
+  }
+
+  FieldSpan span = get_bounds(row);
+  if (!span.is_valid() || span.start >= len_) {
+    return std::string();
+  }
+
+  size_t start = static_cast<size_t>(span.start);
+  size_t end = std::min(static_cast<size_t>(span.end), len_);
+
+  // Handle CR in CRLF endings
+  if (end > start && buf_[end - 1] == '\r') {
+    --end;
+  }
+
+  if (end < start) {
+    end = start;
+  }
+
+  std::string_view raw(reinterpret_cast<const char*>(buf_ + start), end - start);
+
+  // Handle quoted fields - unescape
+  if (raw.empty() || raw.front() != dialect_.quote_char) {
+    return std::string(raw);
+  }
+
+  if (raw.size() < 2 || raw.back() != dialect_.quote_char) {
+    return std::string(raw);
+  }
+
+  // Strip quotes and unescape doubled quotes
+  std::string_view inner = raw.substr(1, raw.size() - 2);
+  std::string result;
+  result.reserve(inner.size());
+
+  for (size_t i = 0; i < inner.size(); ++i) {
+    char c = inner[i];
+    if (c == dialect_.escape_char && i + 1 < inner.size() && inner[i + 1] == dialect_.quote_char) {
+      result += dialect_.quote_char;
+      ++i;
+    } else {
+      result += c;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * @brief Create a LazyColumn from a ValueExtractor.
+ *
+ * Factory function to create a LazyColumn from an existing ValueExtractor,
+ * inheriting its buffer, index, dialect, and config.
+ *
+ * @param extractor Source ValueExtractor
+ * @param col Column index (0-based)
+ * @return LazyColumn for the specified column
+ */
+inline LazyColumn get_lazy_column(const ValueExtractor& extractor, size_t col) {
+  return extractor.get_lazy_column(col);
+}
+
+} // namespace libvroom
 
 #endif // LIBVROOM_VALUE_EXTRACTION_H

--- a/src/libvroom/src/error.cpp
+++ b/src/libvroom/src/error.cpp
@@ -74,7 +74,7 @@ std::string ParseError::to_string() const {
 }
 
 std::string ErrorCollector::summary() const {
-  if (errors_.empty()) {
+  if (errors_.empty() && suppressed_count_ == 0) {
     return "No errors";
   }
 
@@ -107,9 +107,16 @@ std::string ErrorCollector::summary() const {
   if (warnings > 0 || errors > 0 || fatal > 0)
     ss << ")";
 
-  ss << "\n\nDetails:\n";
-  for (const auto& err : errors_) {
-    ss << err.to_string() << "\n";
+  if (suppressed_count_ > 0) {
+    ss << "\nError limit reached: " << suppressed_count_ << " additional error"
+       << (suppressed_count_ == 1 ? "" : "s") << " suppressed";
+  }
+
+  if (!errors_.empty()) {
+    ss << "\n\nDetails:\n";
+    for (const auto& err : errors_) {
+      ss << err.to_string() << "\n";
+    }
   }
 
   return ss.str();

--- a/src/libvroom_index.cc
+++ b/src/libvroom_index.cc
@@ -82,6 +82,9 @@ libvroom_index::libvroom_index(
   // Parse - this creates the index but doesn't build ValueExtractor yet
   TIME_BLOCK("parser.parse", result_ = parser.parse(buffer_.data(), buffer_.size(), opts));
 
+  // Compact the index to enable O(1) field access (vs O(num_threads) chunked)
+  TIME_BLOCK("compact", result_.compact());
+
   if (!result_.successful) {
     if (errors && result_.has_errors()) {
       for (const auto& err : result_.errors()) {


### PR DESCRIPTION
## Summary

- Add `result_.compact()` call after parsing to enable O(1) field access
- Sync bundled libvroom with upstream to include compact() method and other recent improvements

## Background

Hypothesis H6 was **CONFIRMED** in jimhester/libvroom#612: `compact()` provides 1.5-1.7x improvement for field access throughput:

| Config | Throughput | Speedup |
|--------|------------|---------|
| 100K rows, NoCompact | 316.4M rows/sec | - |
| 100K rows, WithCompact | 531.6M rows/sec | **1.68x** |
| 1M rows, NoCompact | 189.1M rows/sec | - |
| 1M rows, WithCompact | 240.9M rows/sec | **1.27x** |

## Changes

1. `src/libvroom_index.cc`: Added `compact()` call after parsing
2. `src/libvroom/`: Synced bundled libvroom with upstream

## Test plan

- [x] vroom tests pass (1200 tests, 0 failures)
- [x] Package builds successfully

Closes jimhester/libvroom#613