### PR TITLE
Clarify double-negation guard in vroom_fwf positional skip logic

### DIFF
--- a/R/vroom_fwf.R
+++ b/R/vroom_fwf.R
@@ -161,11 +161,9 @@ vroom_fwf <- function(
     # Drop skipped columns from output (positional skip notation)
     if (length(col_types_int) > 0) {
       skip_mask <- col_types_int == -1L
-      if (
-        any(skip_mask) &&
-          !(!is.null(resolved_spec) &&
-            inherits(resolved_spec$default, "collector_skip"))
-      ) {
+      already_handled_by_cols_only <- !is.null(resolved_spec) &&
+        inherits(resolved_spec$default, "collector_skip")
+      if (any(skip_mask) && !already_handled_by_cols_only) {
         keep <- !skip_mask[seq_len(min(length(skip_mask), ncol(out)))]
         if (length(keep) < ncol(out)) {
           keep <- c(keep, rep(TRUE, ncol(out) - length(keep)))


### PR DESCRIPTION
## Summary
- Extract `!(!is.null(resolved_spec) && inherits(..., "collector_skip"))` into a named variable `already_handled_by_cols_only` for readability
- Pure refactor, no behavior change

## Test plan
- [x] All 166 existing `test-vroom_fwf.R` tests pass (covers both `col_skip` and `cols_only()` paths)

Closes #19