### PR TITLE
Support compressed and remote files in libvroom backend

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -319,6 +319,11 @@ is_url <- function(path) {
   grepl("^((http|ftp)s?|sftp)://", path)
 }
 
+is_compressed_path <- function(path) {
+  ext <- tolower(tools::file_ext(path))
+  ext %in% c("gz", "bz2", "xz", "zip", "zst")
+}
+
 check_path <- function(path, call = caller_env()) {
   if (file.exists(path)) {
     return(normalizePath_utf8(path, mustWork = FALSE))

--- a/tests/testthat/test-libvroom.R
+++ b/tests/testthat/test-libvroom.R
@@ -852,3 +852,99 @@ test_that("libvroom handles cols_only() with custom col_names", {
     tibble::tibble(x = c(1L, 3L), z = c("hello", "world"))
   )
 })
+
+test_that("libvroom reads gzip-compressed CSV files", {
+  expected <- vroom(
+    vroom_example("mtcars.csv"),
+    delim = ",",
+    show_col_types = FALSE
+  )
+  actual <- vroom(
+    vroom_example("mtcars.csv.gz"),
+    delim = ",",
+    use_libvroom = TRUE,
+    show_col_types = FALSE
+  )
+  expect_equal(actual, expected)
+  expect_s3_class(actual, "spec_tbl_df")
+})
+
+test_that("libvroom reads bz2-compressed CSV files", {
+  expected <- vroom(
+    vroom_example("mtcars.csv"),
+    delim = ",",
+    show_col_types = FALSE
+  )
+  actual <- vroom(
+    vroom_example("mtcars.csv.bz2"),
+    delim = ",",
+    use_libvroom = TRUE,
+    show_col_types = FALSE
+  )
+  expect_equal(actual, expected)
+  expect_s3_class(actual, "spec_tbl_df")
+})
+
+test_that("libvroom reads xz-compressed CSV files", {
+  expected <- vroom(
+    vroom_example("mtcars.csv"),
+    delim = ",",
+    show_col_types = FALSE
+  )
+  actual <- vroom(
+    vroom_example("mtcars.csv.xz"),
+    delim = ",",
+    use_libvroom = TRUE,
+    show_col_types = FALSE
+  )
+  expect_equal(actual, expected)
+  expect_s3_class(actual, "spec_tbl_df")
+})
+
+test_that("libvroom reads zip-compressed CSV files", {
+  expected <- vroom(
+    vroom_example("mtcars.csv"),
+    delim = ",",
+    show_col_types = FALSE
+  )
+  actual <- vroom(
+    vroom_example("mtcars.csv.zip"),
+    delim = ",",
+    use_libvroom = TRUE,
+    show_col_types = FALSE
+  )
+  expect_equal(actual, expected)
+  expect_s3_class(actual, "spec_tbl_df")
+})
+
+test_that("libvroom reads I() literal data", {
+  actual <- vroom(
+    I("a,b,c\n1,2,3\n4,5,6\n"),
+    delim = ",",
+    use_libvroom = TRUE,
+    show_col_types = FALSE
+  )
+  expect_equal(
+    actual,
+    tibble::tibble(a = c(1L, 4L), b = c(2L, 5L), c = c(3L, 6L))
+  )
+  expect_s3_class(actual, "spec_tbl_df")
+})
+
+test_that("libvroom reads remote CSV files", {
+  skip_if_offline()
+
+  actual <- vroom(
+    "https://raw.githubusercontent.com/tidyverse/vroom/main/inst/extdata/mtcars.csv",
+    delim = ",",
+    use_libvroom = TRUE,
+    show_col_types = FALSE
+  )
+  expected <- vroom(
+    vroom_example("mtcars.csv"),
+    delim = ",",
+    show_col_types = FALSE
+  )
+  expect_equal(actual, expected)
+  expect_s3_class(actual, "spec_tbl_df")
+})


### PR DESCRIPTION
## Summary

- Remove the URL and compressed-file gates from `can_use_libvroom()` so compressed files (.gz, .bz2, .xz, .zip, .zst) and remote URLs (http/ftp) route through the libvroom SIMD backend
- Add `connection_or_filepath()` call in the libvroom code path to transparently decompress/download inputs, only for URLs and compressed files (plain local files still pass as paths for memory-mapping)
- Add non-ASCII path guard for proper encoding handling on non-UTF-8 locales
- Add `is_compressed_path()` helper in `R/path.R`

## Test plan

- [x] Tests for gz, bz2, xz, zip compressed files via `use_libvroom = TRUE`
- [x] Test for `I()` literal data via `use_libvroom = TRUE`
- [x] Test for remote CSV URL via `use_libvroom = TRUE` (with `skip_if_offline()`)
- [x] Full test suite: FAIL 0 | WARN 0 | SKIP 1 | PASS 1363

Closes #27