### PR TITLE
Add backslash escape support to libvroom parser (#41)

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -68,8 +68,8 @@ vroom_lines_libvroom_ <- function(input, skip, n_max, na_values, skip_empty_rows
   .Call(`_vroom_vroom_lines_libvroom_`, input, skip, n_max, na_values, skip_empty_rows, num_threads, use_altrep)
 }
 
-vroom_libvroom_ <- function(input, delim, quote, has_header, skip, comment, skip_empty_rows, trim_ws, na_values, num_threads, strings_as_factors, use_altrep, col_types, col_type_names, default_col_type) {
-  .Call(`_vroom_vroom_libvroom_`, input, delim, quote, has_header, skip, comment, skip_empty_rows, trim_ws, na_values, num_threads, strings_as_factors, use_altrep, col_types, col_type_names, default_col_type)
+vroom_libvroom_ <- function(input, delim, quote, has_header, skip, comment, skip_empty_rows, trim_ws, na_values, num_threads, strings_as_factors, use_altrep, col_types, col_type_names, default_col_type, escape_backslash) {
+  .Call(`_vroom_vroom_libvroom_`, input, delim, quote, has_header, skip, comment, skip_empty_rows, trim_ws, na_values, num_threads, strings_as_factors, use_altrep, col_types, col_type_names, default_col_type, escape_backslash)
 }
 
 vroom_write_ <- function(input, filename, delim, eol, na_str, col_names, append, options, num_threads, progress, buf_lines) {

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -315,7 +315,8 @@ vroom <- function(
           },
           col_types = col_types_int,
           col_type_names = libvroom_col_type_names,
-          default_col_type = default_col_type
+          default_col_type = default_col_type,
+          escape_backslash = escape_backslash
         ),
         error = function(e) {
           if (
@@ -663,11 +664,8 @@ can_use_libvroom <- function(
     return(FALSE)
   }
 
-  # Must use default escape behavior
-  if (!isTRUE(escape_double)) {
-    return(FALSE)
-  }
-  if (isTRUE(escape_backslash)) {
+  # Must use escape_double or escape_backslash (not neither)
+  if (!isTRUE(escape_double) && !isTRUE(escape_backslash)) {
     return(FALSE)
   }
 

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -126,10 +126,10 @@ extern "C" SEXP _vroom_vroom_lines_libvroom_(SEXP input, SEXP skip, SEXP n_max, 
   END_CPP11
 }
 // vroom_new.cpp
-cpp11::sexp vroom_libvroom_(SEXP input, const std::string& delim, char quote, bool has_header, int skip, const std::string& comment, bool skip_empty_rows, bool trim_ws, const std::string& na_values, int num_threads, bool strings_as_factors, bool use_altrep, const std::vector<int>& col_types, const cpp11::strings& col_type_names, int default_col_type);
-extern "C" SEXP _vroom_vroom_libvroom_(SEXP input, SEXP delim, SEXP quote, SEXP has_header, SEXP skip, SEXP comment, SEXP skip_empty_rows, SEXP trim_ws, SEXP na_values, SEXP num_threads, SEXP strings_as_factors, SEXP use_altrep, SEXP col_types, SEXP col_type_names, SEXP default_col_type) {
+cpp11::sexp vroom_libvroom_(SEXP input, const std::string& delim, char quote, bool has_header, int skip, const std::string& comment, bool skip_empty_rows, bool trim_ws, const std::string& na_values, int num_threads, bool strings_as_factors, bool use_altrep, const std::vector<int>& col_types, const cpp11::strings& col_type_names, int default_col_type, bool escape_backslash);
+extern "C" SEXP _vroom_vroom_libvroom_(SEXP input, SEXP delim, SEXP quote, SEXP has_header, SEXP skip, SEXP comment, SEXP skip_empty_rows, SEXP trim_ws, SEXP na_values, SEXP num_threads, SEXP strings_as_factors, SEXP use_altrep, SEXP col_types, SEXP col_type_names, SEXP default_col_type, SEXP escape_backslash) {
   BEGIN_CPP11
-    return cpp11::as_sexp(vroom_libvroom_(cpp11::as_cpp<cpp11::decay_t<SEXP>>(input), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(delim), cpp11::as_cpp<cpp11::decay_t<char>>(quote), cpp11::as_cpp<cpp11::decay_t<bool>>(has_header), cpp11::as_cpp<cpp11::decay_t<int>>(skip), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(comment), cpp11::as_cpp<cpp11::decay_t<bool>>(skip_empty_rows), cpp11::as_cpp<cpp11::decay_t<bool>>(trim_ws), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(na_values), cpp11::as_cpp<cpp11::decay_t<int>>(num_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(strings_as_factors), cpp11::as_cpp<cpp11::decay_t<bool>>(use_altrep), cpp11::as_cpp<cpp11::decay_t<const std::vector<int>&>>(col_types), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(col_type_names), cpp11::as_cpp<cpp11::decay_t<int>>(default_col_type)));
+    return cpp11::as_sexp(vroom_libvroom_(cpp11::as_cpp<cpp11::decay_t<SEXP>>(input), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(delim), cpp11::as_cpp<cpp11::decay_t<char>>(quote), cpp11::as_cpp<cpp11::decay_t<bool>>(has_header), cpp11::as_cpp<cpp11::decay_t<int>>(skip), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(comment), cpp11::as_cpp<cpp11::decay_t<bool>>(skip_empty_rows), cpp11::as_cpp<cpp11::decay_t<bool>>(trim_ws), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(na_values), cpp11::as_cpp<cpp11::decay_t<int>>(num_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(strings_as_factors), cpp11::as_cpp<cpp11::decay_t<bool>>(use_altrep), cpp11::as_cpp<cpp11::decay_t<const std::vector<int>&>>(col_types), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(col_type_names), cpp11::as_cpp<cpp11::decay_t<int>>(default_col_type), cpp11::as_cpp<cpp11::decay_t<bool>>(escape_backslash)));
   END_CPP11
 }
 // vroom_write.cc
@@ -170,7 +170,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_vroom_vroom_errors_",           (DL_FUNC) &_vroom_vroom_errors_,            1},
     {"_vroom_vroom_format_",           (DL_FUNC) &_vroom_vroom_format_,           10},
     {"_vroom_vroom_fwf_",              (DL_FUNC) &_vroom_vroom_fwf_,              19},
-    {"_vroom_vroom_libvroom_",         (DL_FUNC) &_vroom_vroom_libvroom_,         15},
+    {"_vroom_vroom_libvroom_",         (DL_FUNC) &_vroom_vroom_libvroom_,         16},
     {"_vroom_vroom_libvroom_fwf_",     (DL_FUNC) &_vroom_vroom_libvroom_fwf_,     13},
     {"_vroom_vroom_lines_libvroom_",   (DL_FUNC) &_vroom_vroom_lines_libvroom_,    7},
     {"_vroom_vroom_materialize",       (DL_FUNC) &_vroom_vroom_materialize,        2},

--- a/src/libvroom/include/libvroom/options.h
+++ b/src/libvroom/include/libvroom/options.h
@@ -15,7 +15,7 @@ namespace libvroom {
 struct CsvOptions {
   char separator = '\0'; // '\0' = auto-detect via DialectDetector
   char quote = '"';
-  char escape = '\\';
+  bool escape_backslash = false; // Use backslash escaping instead of doubled quotes
   char comment = '\0'; // No comment char by default
   bool has_header = true;
   bool skip_empty_rows = true;

--- a/src/libvroom/include/libvroom/parse_utils.h
+++ b/src/libvroom/include/libvroom/parse_utils.h
@@ -42,6 +42,31 @@ inline std::string unescape_quotes(std::string_view value, char quote,
   return result;
 }
 
+// Helper function to unescape backslash-escaped characters in a field.
+// Strips each backslash and keeps the character after it (no C-style conversion).
+// E.g., \, -> ,   \" -> "   \\ -> \   \n -> n (literal, not newline)
+inline std::string unescape_backslash(std::string_view value) {
+  // Fast path: no backslash
+  if (value.find('\\') == std::string_view::npos) {
+    return std::string(value);
+  }
+
+  std::string result;
+  result.reserve(value.size());
+
+  for (size_t i = 0; i < value.size(); ++i) {
+    if (value[i] == '\\' && i + 1 < value.size()) {
+      // Skip the backslash, keep the next character
+      ++i;
+      result += value[i];
+    } else {
+      result += value[i];
+    }
+  }
+
+  return result;
+}
+
 // Helper class for fast null value checking
 // Pre-parses the null values string once. Uses simple linear search since
 // the number of null values is typically very small (3-5 items).

--- a/src/libvroom/include/libvroom/vroom.h
+++ b/src/libvroom/include/libvroom/vroom.h
@@ -264,7 +264,7 @@ private:
 // Chunk boundary finder
 class ChunkFinder {
 public:
-  explicit ChunkFinder(char separator = ',', char quote = '"');
+  explicit ChunkFinder(char separator = ',', char quote = '"', bool escape_backslash = false);
 
   // Find all chunk boundaries in the data
   std::vector<ChunkBoundary> find_chunks(const char* data, size_t size, size_t target_chunk_size);
@@ -280,20 +280,24 @@ public:
 private:
   char separator_;
   char quote_;
+  bool escape_backslash_;
 };
 
 // SIMD-accelerated row counting functions
 // Returns (row_count, offset_after_last_complete_row)
-std::pair<size_t, size_t> count_rows_simd(const char* data, size_t size, char quote_char = '"');
+std::pair<size_t, size_t> count_rows_simd(const char* data, size_t size, char quote_char = '"',
+                                          bool escape_backslash = false);
 
 // Scalar row counting (for verification and small data)
-std::pair<size_t, size_t> count_rows_scalar(const char* data, size_t size, char quote_char = '"');
+std::pair<size_t, size_t> count_rows_scalar(const char* data, size_t size, char quote_char = '"',
+                                            bool escape_backslash = false);
 
 // Analyze chunk with known starting quote state
 // Returns (row_count, last_row_end_offset, ends_inside_quote)
 std::tuple<size_t, size_t, bool> analyze_chunk_simd(const char* data, size_t size,
                                                     char quote_char = '"',
-                                                    bool start_inside_quote = false);
+                                                    bool start_inside_quote = false,
+                                                    bool escape_backslash = false);
 
 // Dual-state chunk analysis result (like Polars LineStats[2])
 struct DualStateChunkStats {
@@ -316,14 +320,17 @@ struct DualStateChunkStats {
 // Computes stats for BOTH starting states simultaneously using SIMD
 // This is the key optimization: one pass instead of two
 DualStateChunkStats analyze_chunk_dual_state_simd(const char* data, size_t size,
-                                                  char quote_char = '"');
+                                                  char quote_char = '"',
+                                                  bool escape_backslash = false);
 
 // SIMD-accelerated find_row_end
 // Returns offset of first byte after row terminator, starting from 'start'
-size_t find_row_end_simd(const char* data, size_t size, size_t start = 0, char quote_char = '"');
+size_t find_row_end_simd(const char* data, size_t size, size_t start = 0, char quote_char = '"',
+                         bool escape_backslash = false);
 
 // Scalar find_row_end (for verification and small data)
-size_t find_row_end_scalar(const char* data, size_t size, size_t start = 0, char quote_char = '"');
+size_t find_row_end_scalar(const char* data, size_t size, size_t start = 0, char quote_char = '"',
+                           bool escape_backslash = false);
 
 // Line parser - parses fields directly to column builders
 class LineParser {

--- a/src/libvroom/src/parser/chunk_finder.cpp
+++ b/src/libvroom/src/parser/chunk_finder.cpp
@@ -7,16 +7,17 @@ namespace libvroom {
 // Threshold for using SIMD vs scalar - SIMD has setup overhead
 constexpr size_t kSimdThreshold = 64;
 
-ChunkFinder::ChunkFinder(char separator, char quote) : separator_(separator), quote_(quote) {}
+ChunkFinder::ChunkFinder(char separator, char quote, bool escape_backslash)
+    : separator_(separator), quote_(quote), escape_backslash_(escape_backslash) {}
 
 size_t ChunkFinder::find_row_end(const char* data, size_t size, size_t start) {
   // Use SIMD for large enough remaining data
   size_t remaining = size - start;
   if (remaining >= kSimdThreshold) {
-    return find_row_end_simd(data, size, start, quote_);
+    return find_row_end_simd(data, size, start, quote_, escape_backslash_);
   }
   // Fall back to scalar for small data
-  return find_row_end_scalar(data, size, start, quote_);
+  return find_row_end_scalar(data, size, start, quote_, escape_backslash_);
 }
 
 std::vector<ChunkBoundary> ChunkFinder::find_chunks(const char* data, size_t size,
@@ -81,9 +82,9 @@ std::vector<ChunkBoundary> ChunkFinder::find_chunks(const char* data, size_t siz
 
 std::pair<size_t, size_t> ChunkFinder::count_rows(const char* data, size_t size) {
   if (size < kSimdThreshold) {
-    return count_rows_scalar(data, size, quote_);
+    return count_rows_scalar(data, size, quote_, escape_backslash_);
   }
-  return count_rows_simd(data, size, quote_);
+  return count_rows_simd(data, size, quote_, escape_backslash_);
 }
 
 } // namespace libvroom

--- a/src/libvroom/src/parser/line_parser.cpp
+++ b/src/libvroom/src/parser/line_parser.cpp
@@ -59,7 +59,9 @@ std::vector<std::string> LineParser::parse_header(const char* data, size_t size)
       break;
     }
 
-    if (c == options_.quote) {
+    if (options_.escape_backslash && c == '\\' && i + 1 < size) {
+      current_field += data[++i];
+    } else if (c == options_.quote) {
       if (in_quote && i + 1 < size && data[i + 1] == options_.quote) {
         // Escaped quote (doubled)
         current_field += options_.quote;
@@ -129,7 +131,9 @@ size_t LineParser::parse_line(const char* data, size_t size,
       break;
     }
 
-    if (c == options_.quote) {
+    if (options_.escape_backslash && c == '\\' && i + 1 < size) {
+      current_field += data[++i];
+    } else if (c == options_.quote) {
       if (in_quote && i + 1 < size && data[i + 1] == options_.quote) {
         // Escaped quote (doubled)
         current_field += options_.quote;

--- a/src/libvroom/src/parser/split_fields_iter.cpp
+++ b/src/libvroom/src/parser/split_fields_iter.cpp
@@ -16,6 +16,7 @@ namespace libvroom {
 // Export implementations for dynamic dispatch
 HWY_EXPORT(ScanForCharImpl);
 HWY_EXPORT(ScanForTwoCharsImpl);
+HWY_EXPORT(ScanForThreeCharsImpl);
 
 // Public API functions
 uint64_t scan_for_char_simd(const char* data, size_t len, char c) {
@@ -24,6 +25,10 @@ uint64_t scan_for_char_simd(const char* data, size_t len, char c) {
 
 uint64_t scan_for_two_chars_simd(const char* data, size_t len, char c1, char c2) {
   return HWY_DYNAMIC_DISPATCH(ScanForTwoCharsImpl)(data, len, c1, c2);
+}
+
+uint64_t scan_for_three_chars_simd(const char* data, size_t len, char c1, char c2, char c3) {
+  return HWY_DYNAMIC_DISPATCH(ScanForThreeCharsImpl)(data, len, c1, c2, c3);
 }
 
 } // namespace libvroom

--- a/src/libvroom/src/schema/type_inference.cpp
+++ b/src/libvroom/src/schema/type_inference.cpp
@@ -150,7 +150,7 @@ std::vector<DataType> TypeInference::infer_from_sample(const char* data, size_t 
   }
 
   LineParser parser(options_);
-  ChunkFinder finder(options_.separator, options_.quote);
+  ChunkFinder finder(options_.separator, options_.quote, options_.escape_backslash);
 
   size_t offset = 0;
   size_t rows_sampled = 0;
@@ -185,7 +185,9 @@ std::vector<DataType> TypeInference::infer_from_sample(const char* data, size_t 
         break;
       }
 
-      if (c == options_.quote) {
+      if (options_.escape_backslash && c == '\\' && i + 1 < row_end) {
+        current_field += data[++i];
+      } else if (c == options_.quote) {
         if (in_quote && i + 1 < row_end && data[i + 1] == options_.quote) {
           current_field += options_.quote;
           ++i;

--- a/src/vroom_new.cpp
+++ b/src/vroom_new.cpp
@@ -58,9 +58,11 @@ errors_to_r_problems(const std::vector<libvroom::ParseError>& errors) {
     bool use_altrep,
     const std::vector<int>& col_types,
     const cpp11::strings& col_type_names,
-    int default_col_type) {
+    int default_col_type,
+    bool escape_backslash) {
 
   libvroom::CsvOptions opts;
+  opts.escape_backslash = escape_backslash;
   if (!delim.empty())
     opts.separator = delim[0];
   opts.quote = quote;


### PR DESCRIPTION
## Summary
- Implement SIMD-accelerated backslash escape handling using simdjson's odd/even backslash run technique, allowing the libvroom backend to parse CSV files with `escape_backslash=TRUE`
- Thread escape-awareness through the entire parsing pipeline: SIMD chunk analysis, field splitting, line parsing, type inference, and field value extraction
- Remove the `escape_backslash` gate in `can_use_libvroom()` so the libvroom backend is used when either `escape_double=TRUE` or `escape_backslash=TRUE`

## Test plan
- [x] 10 new test cases covering: escaped delimiters, escaped quotes, escaped backslashes, escaped newlines, `\\"` edge cases, mixed escapes, quoted fields, header names, legacy parity, and numeric column types
- [x] All 1462 existing tests pass (0 failures)
- [x] `devtools::test(filter = "libvroom")` — 177 tests pass
- [x] `devtools::test(filter = "vroom")` — 768 tests pass

Closes #41