### PR TITLE
Fix racecar emoji direction on Windows pkgdown site

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,9 @@
+/* Fix racecar emoji direction on Windows (#44)
+   Bootstrap 5's default font stack lists "Segoe UI" before "Segoe UI Emoji",
+   causing Windows to render the racecar emoji facing the wrong direction.
+   Moving "Segoe UI Emoji" to the front ensures the color emoji font is used. */
+body {
+  font-family: "Segoe UI Emoji", system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}


### PR DESCRIPTION
## Summary
- Adds `pkgdown/extra.css` that moves `"Segoe UI Emoji"` to the front of the CSS font stack
- Bootstrap 5's default stack lists `"Segoe UI"` before `"Segoe UI Emoji"`, causing Windows to render the racecar emoji (🏎) facing the wrong direction
- `"Segoe UI Emoji"` only contains emoji glyphs, so regular text falls through to the subsequent fonts in the stack

Closes #44

## Test plan
- [ ] Verify pkgdown site builds successfully with the new `extra.css`
- [ ] On Windows, confirm the racecar emoji in the heading faces the correct direction
- [ ] On macOS/Linux, confirm no visual regression in text or emoji rendering