### PR TITLE
Restore vroom_rle Altrep vector for multi-file id column

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -40,6 +40,10 @@ vroom_libvroom_ <- function(input, delim, quote, has_header, skip, comment, skip
   .Call(`_vroom_vroom_libvroom_`, input, delim, quote, has_header, skip, comment, skip_empty_rows, trim_ws, na_values, num_threads, strings_as_factors, use_altrep, col_types, col_type_names, default_col_type, escape_backslash, decimal_mark, guess_max)
 }
 
+vroom_rle_make <- function(input) {
+  .Call(`_vroom_vroom_rle_make`, input)
+}
+
 has_trailing_newline <- function(filename) {
   .Call(`_vroom_has_trailing_newline`, filename)
 }

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -536,12 +536,12 @@ vroom <- function(
       # Add id column if requested
       if (!is.null(id)) {
         file_path <- original_path
+        nr <- nrow(res$data)
+        rle_input <- stats::setNames(as.integer(nr), file_path)
+        id_col <- vroom_rle_make(rle_input)
         res$data <- cbind(
           stats::setNames(
-            data.frame(
-              rep(file_path, nrow(res$data)),
-              stringsAsFactors = FALSE
-            ),
+            data.frame(id_col, stringsAsFactors = FALSE),
             id
           ),
           res$data

--- a/src/Makevars
+++ b/src/Makevars
@@ -53,7 +53,7 @@ HIGHWAY_SOURCES = libvroom/third_party/hwy/aligned_allocator.cc \
 	libvroom/third_party/hwy/per_target.cc \
 	libvroom/third_party/hwy/targets.cc
 
-OBJECTS = arrow_to_r.o libvroom_helpers.o vroom_arrow_chr.o vroom_dict_chr.o vroom_new.o vroom_arrow.o vroom_fwf_libvroom.o vroom_lines_libvroom.o \
+OBJECTS = arrow_to_r.o libvroom_helpers.o vroom_arrow_chr.o vroom_dict_chr.o vroom_new.o vroom_arrow.o vroom_fwf_libvroom.o vroom_lines_libvroom.o vroom_rle.o \
 	Iconv.o LocaleInfo.o altrep.o cpp11.o \
 	gen.o grisu3.o guess_type.o \
 	iconv_file.o parse_helpers.o vroom_utils.o vroom_write.o \

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -75,6 +75,13 @@ extern "C" SEXP _vroom_vroom_libvroom_(SEXP input, SEXP delim, SEXP quote, SEXP 
     return cpp11::as_sexp(vroom_libvroom_(cpp11::as_cpp<cpp11::decay_t<SEXP>>(input), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(delim), cpp11::as_cpp<cpp11::decay_t<char>>(quote), cpp11::as_cpp<cpp11::decay_t<bool>>(has_header), cpp11::as_cpp<cpp11::decay_t<int>>(skip), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(comment), cpp11::as_cpp<cpp11::decay_t<bool>>(skip_empty_rows), cpp11::as_cpp<cpp11::decay_t<bool>>(trim_ws), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(na_values), cpp11::as_cpp<cpp11::decay_t<int>>(num_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(strings_as_factors), cpp11::as_cpp<cpp11::decay_t<bool>>(use_altrep), cpp11::as_cpp<cpp11::decay_t<const std::vector<int>&>>(col_types), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(col_type_names), cpp11::as_cpp<cpp11::decay_t<int>>(default_col_type), cpp11::as_cpp<cpp11::decay_t<bool>>(escape_backslash), cpp11::as_cpp<cpp11::decay_t<char>>(decimal_mark), cpp11::as_cpp<cpp11::decay_t<int>>(guess_max)));
   END_CPP11
 }
+// vroom_rle.cc
+SEXP vroom_rle_make(cpp11::integers input);
+extern "C" SEXP _vroom_vroom_rle_make(SEXP input) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(vroom_rle_make(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(input)));
+  END_CPP11
+}
 // vroom_utils.cpp
 bool has_trailing_newline(const cpp11::strings& filename);
 extern "C" SEXP _vroom_has_trailing_newline(SEXP filename) {
@@ -158,6 +165,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_vroom_vroom_libvroom_fwf_",     (DL_FUNC) &_vroom_vroom_libvroom_fwf_,     13},
     {"_vroom_vroom_lines_libvroom_",   (DL_FUNC) &_vroom_vroom_lines_libvroom_,    7},
     {"_vroom_vroom_materialize",       (DL_FUNC) &_vroom_vroom_materialize,        2},
+    {"_vroom_vroom_rle_make",          (DL_FUNC) &_vroom_vroom_rle_make,           1},
     {"_vroom_vroom_str_",              (DL_FUNC) &_vroom_vroom_str_,               1},
     {"_vroom_vroom_write_",            (DL_FUNC) &_vroom_vroom_write_,            11},
     {"_vroom_vroom_write_connection_", (DL_FUNC) &_vroom_vroom_write_connection_, 12},
@@ -168,11 +176,13 @@ static const R_CallMethodDef CallEntries[] = {
 
 void init_vroom_arrow_chr(DllInfo* dll);
 void init_vroom_dict_chr(DllInfo* dll);
+void init_vroom_rle(DllInfo* dll);
 
 extern "C" attribute_visible void R_init_vroom(DllInfo* dll){
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
   init_vroom_arrow_chr(dll);
   init_vroom_dict_chr(dll);
+  init_vroom_rle(dll);
   R_forceSymbols(dll, TRUE);
 }

--- a/src/vroom_rle.cc
+++ b/src/vroom_rle.cc
@@ -1,0 +1,10 @@
+#include "vroom_rle.h"
+#include <cpp11.hpp>
+
+R_altrep_class_t vroom_rle::class_t;
+
+void init_vroom_rle(DllInfo* dll) { vroom_rle::Init(dll); }
+
+[[cpp11::register]] SEXP vroom_rle_make(cpp11::integers input) {
+  return vroom_rle::Make(input);
+}

--- a/src/vroom_rle.h
+++ b/src/vroom_rle.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include "altrep.h"
+#include "r_utils.h"
+
+class vroom_rle {
+
+public:
+  static R_altrep_class_t class_t;
+
+  static SEXP Make(SEXP input) {
+
+    SEXP res = R_new_altrep(class_t, input, R_NilValue);
+
+    MARK_NOT_MUTABLE(res); /* force duplicate on modify */
+
+    return res;
+  }
+
+  // ALTREP methods -------------------
+  // The length of the object
+  static inline R_xlen_t Length(SEXP vec) {
+    SEXP data2 = R_altrep_data2(vec);
+    if (data2 != R_NilValue) {
+      return Rf_xlength(data2);
+    }
+    R_xlen_t sz = 0;
+    SEXP rle = R_altrep_data1(vec);
+    int* rle_p = INTEGER(rle);
+
+    for (R_xlen_t i = 0; i < Rf_xlength(rle); ++i) {
+      sz += rle_p[i];
+    }
+
+    return sz;
+  }
+
+  // What gets printed when .Internal(inspect()) is used
+  static Rboolean
+  Inspect(SEXP x, int, int, int, void (*)(SEXP, int, int, int)) {
+    Rprintf(
+        "vroom_rle (len=%" R_PRIdXLEN_T ", materialized=%s)\n",
+        Length(x),
+        R_altrep_data2(x) != R_NilValue ? "T" : "F");
+    return TRUE;
+  }
+
+  // ALTSTRING methods -----------------
+
+  // the element at the index `i`
+  static SEXP string_Elt(SEXP vec, R_xlen_t i) {
+    SEXP data2 = R_altrep_data2(vec);
+    if (data2 != R_NilValue) {
+      return STRING_ELT(data2, i);
+    }
+
+    SEXP rle = R_altrep_data1(vec);
+    int* rle_p = INTEGER(rle);
+    SEXP nms = Rf_getAttrib(rle, Rf_install("names"));
+
+    R_xlen_t idx = 0;
+    while (i >= 0 && idx < Rf_xlength(rle)) {
+      i -= rle_p[idx++];
+    }
+
+    return STRING_ELT(nms, idx - 1);
+  }
+
+  // --- Altvec
+  static SEXP Materialize(SEXP vec) {
+    SEXP data2 = R_altrep_data2(vec);
+    if (data2 != R_NilValue) {
+      return data2;
+    }
+
+    R_xlen_t sz = Length(vec);
+    SEXP rle = R_altrep_data1(vec);
+    int* rle_p = INTEGER(rle);
+
+    SEXP out = PROTECT(Rf_allocVector(STRSXP, sz));
+
+    R_xlen_t idx = 0;
+    SEXP nms = Rf_getAttrib(rle, Rf_install("names"));
+    for (R_xlen_t i = 0; i < Rf_xlength(rle); ++i) {
+      for (R_xlen_t j = 0; j < rle_p[i]; ++j) {
+        SET_STRING_ELT(out, idx++, STRING_ELT(nms, i));
+      }
+    }
+
+    UNPROTECT(1);
+    R_set_altrep_data2(vec, out);
+
+    return out;
+  }
+
+  static void* Dataptr(SEXP vec, Rboolean) {
+    return DATAPTR_RW(Materialize(vec));
+  }
+
+  static const void* Dataptr_or_null(SEXP vec) {
+    SEXP data2 = R_altrep_data2(vec);
+    if (data2 == R_NilValue)
+      return nullptr;
+
+    return DATAPTR_RO(data2);
+  }
+
+  // -------- initialize the altrep class with the methods above
+  static void Init(DllInfo* dll) {
+    vroom_rle::class_t = R_make_altstring_class("vroom_rle", "vroom", dll);
+
+    // altrep
+    R_set_altrep_Length_method(class_t, Length);
+    R_set_altrep_Inspect_method(class_t, Inspect);
+
+    // altvec
+    R_set_altvec_Dataptr_method(class_t, Dataptr);
+    R_set_altvec_Dataptr_or_null_method(class_t, Dataptr_or_null);
+
+    // altstring
+    R_set_altstring_Elt_method(class_t, string_Elt);
+  }
+};
+
+// Called the package is loaded
+[[cpp11::init]] void init_vroom_rle(DllInfo* dll);


### PR DESCRIPTION
## Summary

- Restores the `vroom_rle` Altrep string class (removed in #46) for the `id` column when reading files with `vroom(files, id = "path")`
- Uses RLE-encoded Altrep providing O(n_files) storage instead of O(n_rows) — each file's id column stores only the filename + row count rather than repeating the string for every row
- Single-file reads preserve Altrep on the id column; multi-file reads benefit during per-file construction (materialized when combined via `vctrs::vec_rbind()`)

**Note:** The Altrep RLE is preserved for single-file reads but gets materialized when multiple files are combined via `vctrs::vec_rbind()`. Ideally we'd avoid `vec_rbind()` for multi-file combining to preserve Altrep status end-to-end — see #38.

Closes #54

## Test plan

- [x] Verify id column is Altrep RLE for single-file reads
- [x] Verify id column values are correct for multi-file reads
- [x] Verify id column materializes correctly when accessed
- [x] All existing multi-file tests pass
- [x] Full test suite passes (993 passed, 0 failures)