### PR TITLE
Skip leading blank/whitespace lines before header in libvroom (#53)

### DIFF
--- a/src/libvroom/src/reader/csv_reader.cpp
+++ b/src/libvroom/src/reader/csv_reader.cpp
@@ -385,33 +385,60 @@ struct CsvReader::Impl {
   }
 };
 
-// Skip leading comment lines in the data. Returns offset past all leading comment lines.
-// A comment line starts with the comment character (at column 0) and ends at newline.
-static size_t skip_leading_comment_lines(const char* data, size_t size, char comment_char) {
-  if (comment_char == '\0' || size == 0) {
-    return 0;
-  }
+// Skip leading blank/whitespace-only lines and comment lines before the header.
+// A blank line contains only whitespace (space, tab) and a newline.
+// A comment line has optional leading whitespace followed by the comment character.
+// This matches the legacy vroom behavior in find_first_line() / is_blank_or_comment_line().
+static size_t skip_leading_blank_and_comment_lines(
+    const char* data, size_t size, char comment_char, bool skip_empty_rows) {
+  if (size == 0) return 0;
 
   size_t offset = 0;
   while (offset < size) {
-    // Check if current line starts with comment char
-    if (data[offset] != comment_char) {
-      break; // Not a comment line, stop
+    size_t line_start = offset;
+
+    // Skip leading whitespace on this line
+    while (offset < size && (data[offset] == ' ' || data[offset] == '\t')) {
+      offset++;
     }
 
-    // Skip to end of this comment line (handle \n, \r\n, and bare \r)
-    while (offset < size && data[offset] != '\n' && data[offset] != '\r') {
-      offset++;
+    if (offset >= size) {
+      // Reached end of data while scanning whitespace
+      // If skip_empty_rows is false, rewind — this isn't a blank "line" to skip
+      return skip_empty_rows ? offset : line_start;
     }
-    // Skip past the line ending
-    if (offset < size && data[offset] == '\r') {
-      offset++;
-      if (offset < size && data[offset] == '\n') {
-        offset++; // CRLF
+
+    bool is_blank = (data[offset] == '\n' || data[offset] == '\r');
+    bool is_comment = (comment_char != '\0' && data[offset] == comment_char);
+
+    if (is_blank && skip_empty_rows) {
+      // Whitespace-only line — skip past line ending
+      if (data[offset] == '\r') {
+        offset++;
+        if (offset < size && data[offset] == '\n') offset++;
+      } else {
+        offset++;
       }
-    } else if (offset < size && data[offset] == '\n') {
-      offset++;
+      continue;
     }
+
+    if (is_comment) {
+      // Comment line — skip to end of line
+      while (offset < size && data[offset] != '\n' && data[offset] != '\r') {
+        offset++;
+      }
+      if (offset < size && data[offset] == '\r') {
+        offset++;
+        if (offset < size && data[offset] == '\n') offset++;
+      } else if (offset < size && data[offset] == '\n') {
+        offset++;
+      }
+      continue;
+    }
+
+    // Non-blank, non-comment line — stop; rewind to line_start
+    // so the header parser sees the full line including any leading whitespace
+    return line_start;
   }
   return offset;
 }
@@ -517,16 +544,14 @@ Result<bool> CsvReader::open(const std::string& path) {
   ChunkFinder finder(impl_->options.separator, impl_->options.quote, impl_->options.escape_backslash);
   LineParser parser(impl_->options);
 
-  // Skip leading comment lines before header
-  size_t comment_skip = skip_leading_comment_lines(data, size, impl_->options.comment);
+  // Skip leading blank/whitespace-only lines and comment lines before header
+  size_t comment_skip = skip_leading_blank_and_comment_lines(
+      data, size, impl_->options.comment, impl_->options.skip_empty_rows);
   if (comment_skip > 0) {
     impl_->data_ptr += comment_skip;
     impl_->data_size -= comment_skip;
     data = impl_->data_ptr;
     size = impl_->data_size;
-    if (size == 0) {
-      return Result<bool>::failure("File contains only comment lines");
-    }
   }
 
   // Parse header if present
@@ -695,16 +720,14 @@ Result<bool> CsvReader::open_from_buffer(AlignedBuffer buffer) {
   ChunkFinder finder(impl_->options.separator, impl_->options.quote, impl_->options.escape_backslash);
   LineParser parser(impl_->options);
 
-  // Skip leading comment lines before header
-  size_t comment_skip = skip_leading_comment_lines(data, size, impl_->options.comment);
+  // Skip leading blank/whitespace-only lines and comment lines before header
+  size_t comment_skip = skip_leading_blank_and_comment_lines(
+      data, size, impl_->options.comment, impl_->options.skip_empty_rows);
   if (comment_skip > 0) {
     impl_->data_ptr += comment_skip;
     impl_->data_size -= comment_skip;
     data = impl_->data_ptr;
     size = impl_->data_size;
-    if (size == 0) {
-      return Result<bool>::failure("File contains only comment lines");
-    }
   }
 
   // Parse header if present

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -125,12 +125,6 @@ test_that("vroom escapes backslashes", {
 })
 
 test_that("vroom ignores leading whitespace", {
-  # libvroom treats the first line as the header; it does not skip leading
-
-  # blank/whitespace-only lines to find the header row.
-  skip(
-    "libvroom does not skip leading blank/whitespace lines before the header"
-  )
   test_vroom(
     '\n\n   \t \t\n  \n\na,b,c\n1,2,3\n',
     delim = ",",
@@ -139,11 +133,6 @@ test_that("vroom ignores leading whitespace", {
 })
 
 test_that("vroom ignores comments", {
-  # libvroom treats the first line as the header; leading blank/whitespace-only
-  # lines before a comment + header are not skipped.
-  skip(
-    "libvroom does not skip leading blank/whitespace lines before comments and header"
-  )
   test_vroom(
     '\n\n \t #a,b,c\na,b,c\n1,2,3\n',
     delim = ",",


### PR DESCRIPTION
## Summary

- Replace `skip_leading_comment_lines()` with `skip_leading_blank_and_comment_lines()` in libvroom's CSV reader, which skips blank/whitespace-only lines and whitespace-prefixed comment lines before the header row — matching the legacy vroom parser behavior
- Remove the "file contains only comment lines" hard error so blank-only files gracefully produce empty results
- Unskip 2 tests in `test-vroom.R` ("vroom ignores leading whitespace" and "vroom ignores comments")

Addresses the leading blank lines subset of #53.

## Test plan

- [x] `devtools::test(filter = "vroom")` — 0 failures, 2 previously skipped tests now pass (PASS 559)
- [x] `devtools::test()` — full suite passes with 0 failures (PASS 991)
- [x] Smoke test: `vroom(I("\n\na,b,c\n1,2,3\n"), delim = ",")` returns correct tibble