### PR TITLE
Fix col_select positional indices when id column is present

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -413,45 +413,24 @@ vroom_enquo <- function(x) {
 
 apply_libvroom_col_select <- function(out, col_select, id = NULL) {
   if (inherits(col_select, "quosures") || !quo_is_null(col_select)) {
-    all_names <- names(out)
+    # Build selection pool: data columns first, then id (appended).
+    # Positional indices (e.g., col_select = 1:3) must reference file
+    # (data) columns, not the synthesized id column which is prepended
+    # to the output. Appending id at the end keeps positional semantics
+    # correct while still making the id column selectable by name.
+    data_names <- setdiff(names(out), id)
+    select_pool <- c(data_names, id)
 
-    # For selection purposes, we need special handling when an id column
-    # is present. Positional indices should reference only the non-id
-    # (data) columns, but the id column should still be selectable by name.
-    if (!is.null(id) && id %in% all_names) {
-      # Build a selection namespace where positional indices map to data
-      # columns only (excluding the id column), but the id column is
-      # still available by name.
-      non_id_names <- setdiff(all_names, id)
-
-      if (inherits(col_select, "quosures")) {
-        vars <- tryCatch(
-          tidyselect::vars_select(non_id_names, !!!col_select),
-          error = function(e) {
-            # Fall back to using all names if column wasn't found
-            tidyselect::vars_select(all_names, !!!col_select)
-          }
-        )
-      } else {
-        vars <- tryCatch(
-          tidyselect::vars_select(non_id_names, !!col_select),
-          error = function(e) {
-            tidyselect::vars_select(all_names, !!col_select)
-          }
-        )
-      }
-
-      # Always include the id column
-      if (!id %in% vars) {
-        names(id) <- id
-        vars <- c(id, vars)
-      }
+    if (inherits(col_select, "quosures")) {
+      vars <- tidyselect::vars_select(select_pool, !!!col_select)
     } else {
-      if (inherits(col_select, "quosures")) {
-        vars <- tidyselect::vars_select(all_names, !!!col_select)
-      } else {
-        vars <- tidyselect::vars_select(all_names, !!col_select)
-      }
+      vars <- tidyselect::vars_select(select_pool, !!col_select)
+    }
+
+    # If id exists and wasn't explicitly selected, prepend it.
+    if (!is.null(id) && !id %in% vars) {
+      names(id) <- id
+      vars <- c(id, vars)
     }
 
     out <- out[vars]

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -191,6 +191,20 @@ test_that("referencing columns by position in col_select works with id column (#
   )
 })
 
+test_that("col_select with mixed positional + named id works correctly", {
+  # Position 2 should be "mpg" (second data column), not "model"
+  # (which would happen if id shifts positional indices)
+  expect_named(
+    vroom(
+      vroom_example("mtcars.csv"),
+      id = "path",
+      col_select = c(2, path),
+      show_col_types = FALSE
+    ),
+    c("mpg", "path")
+  )
+})
+
 test_that("col_select works with col_names = FALSE", {
   res <- vroom(
     I("foo\tbar\n1\t2\n"),


### PR DESCRIPTION
## Summary

Fixes a latent bug in `apply_libvroom_col_select()` where mixing positional indices with the id column by name (e.g., `col_select = c(2, path)`) produced wrong results.

**Root cause**: The `tryCatch` fallback used `all_names` (where id is at position 1), silently shifting all positional indices by 1. For example, `col_select = c(2, path)` would select `model` (position 2 in `all_names` = column after id) instead of `mpg` (the actual second data column).

**Fix**: Replace the dual-pool `tryCatch` approach with a single `select_pool = c(data_names, id)` that appends the id column at the end. Positional indices naturally map to data columns, and the id column is still selectable by name.

## Test plan
- [x] New test: `col_select = c(2, path)` with `id = "path"` → `c("mpg", "path")`
- [x] All 19 select tests pass
- [x] `devtools::test()` → FAIL 0 | WARN 10 | SKIP 14 | PASS 1038