### PR TITLE
Wire detected delimiter from C++ to R for spec()$delim

### DIFF
--- a/R/vroom.R
+++ b/R/vroom.R
@@ -460,6 +460,10 @@ vroom <- function(
     # Remove C++-attached problems (will be re-attached by finalize)
     attr(one, "problems") <- NULL
 
+    # Extract detected delimiter from C++ (for spec()$delim)
+    detected_delim <- attr(one, "detected_delim")
+    attr(one, "detected_delim") <- NULL
+
     # Merge R-side problems from post-processing
     r_probs <- attr(one, ".r_problems")
     attr(one, ".r_problems") <- NULL
@@ -472,7 +476,8 @@ vroom <- function(
       data = one,
       problems = probs,
       resolved_spec = resolved_spec,
-      col_types_int = col_types_int
+      col_types_int = col_types_int,
+      detected_delim = detected_delim
     )
   }
 
@@ -638,37 +643,9 @@ vroom <- function(
   # the full file schema, not just selected columns.
   # Exclude the id column from the spec column names.
   all_col_names <- setdiff(names(out), id)
-  # If delimiter was auto-detected (delim is still NULL), try to infer it
-  # from the column names for the spec attribute.
-  spec_delim <- delim %||% ""
-  if (!nzchar(spec_delim) && length(all_col_names) > 1) {
-    # Try to infer the delimiter from the first input file
-    spec_delim <- tryCatch(
-      {
-        first_input <- file[[1]]
-        if (is.character(first_input) && file.exists(first_input)) {
-          lines <- readLines(first_input, n = 5, warn = FALSE)
-        } else if (is.raw(first_input)) {
-          lines <- strsplit(
-            rawToChar(first_input[seq_len(min(
-              2000,
-              length(first_input)
-            ))]),
-            "\n",
-            fixed = TRUE
-          )[[1]]
-        } else {
-          lines <- character()
-        }
-        if (length(lines) > 0) {
-          guess_delim(lines)
-        } else {
-          ""
-        }
-      },
-      error = function(e) ""
-    )
-  }
+  # Use the delimiter that libvroom actually detected (ground truth from C++),
+  # falling back to the user-supplied delim or empty string.
+  spec_delim <- delim %||% first_result$detected_delim %||% ""
   attr(out, "spec") <- build_libvroom_spec(
     out[all_col_names],
     first_result$resolved_spec,

--- a/src/vroom_new.cpp
+++ b/src/vroom_new.cpp
@@ -200,10 +200,19 @@ errors_to_r_problems(const std::vector<libvroom::ParseError>& errors) {
     cpp11::stop("Failed to start streaming: %s", stream_result.error.c_str());
   }
 
-  auto attach_problems = [&reader](cpp11::sexp result) -> cpp11::sexp {
+  // Capture detected dialect (if auto-detected) for spec()$delim
+  auto detected = reader.detected_dialect();
+
+  auto attach_problems = [&reader, &detected](cpp11::sexp result) -> cpp11::sexp {
     const auto& errors = reader.errors();
     if (!errors.empty()) {
       Rf_setAttrib(result, Rf_install("problems"), errors_to_r_problems(errors));
+    }
+    // Attach detected delimiter so R can use it for spec()$delim
+    if (detected.has_value()) {
+      std::string det_delim(1, detected->dialect.delimiter);
+      Rf_setAttrib(result, Rf_install("detected_delim"),
+                   Rf_mkString(det_delim.c_str()));
     }
     return result;
   };

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -685,6 +685,36 @@ test_that("Can return the spec object", {
   expect_equal(obj, exp)
 })
 
+test_that("spec()$delim reflects auto-detected delimiter from C++", {
+  # CSV file
+  tf_csv <- tempfile(fileext = ".csv")
+  on.exit(unlink(c(tf_csv, tf_tsv, tf_pipe)), add = TRUE)
+  writeLines(c("a,b,c", "1,2,3"), tf_csv)
+  res_csv <- vroom(tf_csv, show_col_types = FALSE)
+  expect_equal(spec(res_csv)$delim, ",")
+
+  # TSV file
+  tf_tsv <- tempfile(fileext = ".tsv")
+  writeLines(c("a\tb\tc", "1\t2\t3"), tf_tsv)
+  res_tsv <- vroom(tf_tsv, show_col_types = FALSE)
+  expect_equal(spec(res_tsv)$delim, "\t")
+
+  # Pipe-delimited file
+  tf_pipe <- tempfile()
+  writeLines(c("a|b|c", "1|2|3"), tf_pipe)
+  res_pipe <- vroom(tf_pipe, show_col_types = FALSE)
+  expect_equal(spec(res_pipe)$delim, "|")
+})
+
+test_that("spec()$delim works for connections (not just file paths)", {
+  tf <- tempfile(fileext = ".csv")
+  on.exit(unlink(tf))
+  writeLines(c("a,b,c", "1,2,3"), tf)
+  con <- file(tf, "rb")
+  res <- vroom(con, show_col_types = FALSE)
+  expect_equal(spec(res)$delim, ",")
+})
+
 test_that("vroom handles files with trailing commas, windows newlines, missing a final newline and not null terminated", {
   f <- tempfile()
   on.exit(unlink(f))


### PR DESCRIPTION
## Summary

- Returns the auto-detected delimiter from libvroom's C++ `DialectDetector` as a `"detected_delim"` attribute on the parsed result
- Extracts it in `read_one_libvroom()` and uses it directly for `spec()$delim`, replacing the R-side `guess_delim()` re-read approach
- This fixes `spec()$delim` for connections (previously returned `""` because there was no file path to re-read) and eliminates potential disagreements between R's guess and what libvroom actually used

## Test plan

- [x] Added test for auto-detected CSV, TSV, and pipe delimiters via `spec()$delim`
- [x] Added test for connections (previously broken — returned `""`)
- [x] Full test suite passes: FAIL 0 | WARN 9 | SKIP 14 | PASS 1041