### PR TITLE
Integrate comment detection into SplitFields SIMD boundary scanning

### DIFF
--- a/src/libvroom/include/libvroom/split_fields.h
+++ b/src/libvroom/include/libvroom/split_fields.h
@@ -130,20 +130,24 @@ VROOM_FORCE_INLINE uint64_t scan_for_three_chars(const char* data, size_t len, c
 // Direct port of Polars' SplitFields iterator
 class SplitFields {
 public:
-  // Single-byte separator constructor (SIMD fast path — unchanged)
+  // Single-byte separator constructor (SIMD fast path)
   VROOM_FORCE_INLINE SplitFields(const char* slice, size_t size, char separator, char quote_char,
-                                 char eol_char, bool escape_backslash = false)
+                                 char eol_char, bool escape_backslash = false,
+                                 char comment_char = '\0')
       : v_(slice), remaining_(size), separator_(separator), multi_byte_sep_(false), finished_(false),
         finished_inside_quote_(false), quote_char_(quote_char), quoting_(quote_char != 0),
-        eol_char_(eol_char), previous_valid_ends_(0), escape_backslash_(escape_backslash) {}
+        eol_char_(eol_char), previous_valid_ends_(0), escape_backslash_(escape_backslash),
+        comment_char_(comment_char), hit_comment_(false) {}
 
   // Multi-byte separator constructor (scalar slow path)
   VROOM_FORCE_INLINE SplitFields(const char* slice, size_t size, std::string_view separator,
-                                 char quote_char, char eol_char, bool escape_backslash = false)
+                                 char quote_char, char eol_char, bool escape_backslash = false,
+                                 char comment_char = '\0')
       : v_(slice), remaining_(size), separator_(separator.size() == 1 ? separator[0] : '\0'),
         multi_byte_sep_(separator.size() > 1), separator_str_(separator), finished_(false),
         finished_inside_quote_(false), quote_char_(quote_char), quoting_(quote_char != 0),
-        eol_char_(eol_char), previous_valid_ends_(0), escape_backslash_(escape_backslash) {}
+        eol_char_(eol_char), previous_valid_ends_(0), escape_backslash_(escape_backslash),
+        comment_char_(comment_char), hit_comment_(false) {}
 
   VROOM_FORCE_INLINE bool next(const char*& field_data, size_t& field_len, bool& needs_escaping) {
     if (finished_) {
@@ -162,7 +166,9 @@ public:
 
       needs_escaping = (quoting_ && remaining_ > 0 && v_[0] == quote_char_);
 
-      if (v_[pos] == eol_char_) {
+      char c = v_[pos];
+      if (c == eol_char_ || (comment_char_ != '\0' && c == comment_char_)) {
+        if (comment_char_ != '\0' && c == comment_char_) hit_comment_ = true;
         return finish_eol(field_data, field_len, needs_escaping, pos);
       }
 
@@ -193,7 +199,8 @@ public:
     }
 
     char c = v_[pos];
-    if (c == eol_char_) {
+    if (c == eol_char_ || (comment_char_ != '\0' && c == comment_char_)) {
+      if (comment_char_ != '\0' && c == comment_char_) hit_comment_ = true;
       return finish_eol(field_data, field_len, needs_escaping, pos);
     }
 
@@ -212,6 +219,10 @@ public:
   // had its closing quote found (i.e., the data ended inside a quote).
   VROOM_FORCE_INLINE bool finished_inside_quote() const { return finished_inside_quote_; }
 
+  // Returns true if the iterator stopped because it hit a comment character.
+  // The caller should skip to the actual EOL in the raw data.
+  VROOM_FORCE_INLINE bool hit_comment() const { return hit_comment_; }
+
 private:
   const char* v_;
   size_t remaining_;
@@ -226,8 +237,12 @@ private:
   uint64_t previous_valid_ends_;
   bool escape_backslash_;
   EscapeState escape_state_;
+  char comment_char_;   // Single-char comment for SIMD fast path ('\0' = disabled)
+  bool hit_comment_;    // Set when iterator stopped at a comment char
 
-  VROOM_FORCE_INLINE bool eof_eol(char c) const { return c == separator_ || c == eol_char_; }
+  VROOM_FORCE_INLINE bool eof_eol(char c) const {
+    return c == separator_ || c == eol_char_ || (comment_char_ != '\0' && c == comment_char_);
+  }
 
   // Check if separator matches at position pos in v_
   VROOM_FORCE_INLINE bool matches_sep_at(size_t pos) const {
@@ -258,6 +273,17 @@ private:
       }
 
       if (in_quote) continue;
+
+      // Check for comment char (outside quotes)
+      if (comment_char_ != '\0' && c == comment_char_) {
+        hit_comment_ = true;
+        finished_ = true;
+        field_data = v_;
+        field_len = i;
+        v_ += i + 1;
+        remaining_ -= i + 1;
+        return true;
+      }
 
       // Check for end-of-line
       if (c == '\n' || c == '\r') {
@@ -327,6 +353,10 @@ private:
       uint64_t quote_mask = detail::scan_for_char(bytes, detail::SIMD_SIZE, quote_char_);
 
       uint64_t end_mask = sep_mask | eol_mask;
+      // Comment char outside quotes is also a boundary
+      if (comment_char_ != '\0') {
+        end_mask |= detail::scan_for_char(bytes, detail::SIMD_SIZE, comment_char_);
+      }
 
       // When backslash escaping is enabled, filter out escaped characters.
       // Always call compute_escaped_mask to consume carry bit from previous block.
@@ -389,8 +419,10 @@ private:
     while (remaining_ - total_idx > detail::SIMD_SIZE) {
       const char* bytes = v_ + total_idx;
 
-      uint64_t end_mask =
-          detail::scan_for_two_chars(bytes, detail::SIMD_SIZE, separator_, eol_char_);
+      // Use three-char SIMD scan when comment char is configured, else two-char
+      uint64_t end_mask = (comment_char_ != '\0')
+          ? detail::scan_for_three_chars(bytes, detail::SIMD_SIZE, separator_, eol_char_, comment_char_)
+          : detail::scan_for_two_chars(bytes, detail::SIMD_SIZE, separator_, eol_char_);
 
       // When backslash escaping is enabled, filter out escaped characters.
       // Always call compute_escaped_mask to consume carry bit from previous block.
@@ -416,7 +448,7 @@ private:
       }
     }
 
-    // Scalar fallback
+    // Scalar fallback (eof_eol already includes comment_char_ check)
     const char* bytes = v_ + total_idx;
     size_t len = remaining_ - total_idx;
 

--- a/src/libvroom/src/reader/csv_reader.cpp
+++ b/src/libvroom/src/reader/csv_reader.cpp
@@ -157,6 +157,10 @@ std::pair<size_t, bool> parse_chunk_with_state(
   const char quote = options.quote;
   const std::string_view sep = options.separator;
   const size_t num_cols = columns.size();
+  // For single-char comments, pass to SplitFields for SIMD-accelerated detection.
+  // Multi-char comments still use the scalar post-field scan below.
+  const char comment_char = (options.comment.size() == 1) ? options.comment[0] : '\0';
+  const bool has_multi_char_comment = options.comment.size() > 1;
 
   while (offset < size) {
     // Skip empty lines (when enabled)
@@ -200,7 +204,8 @@ std::pair<size_t, bool> parse_chunk_with_state(
     // Create iterator for remaining data - it stops at EOL
     size_t row_start_offset = offset;
     size_t start_remaining = size - offset;
-    SplitFields iter(data + offset, start_remaining, sep, quote, '\n', options.escape_backslash);
+    SplitFields iter(data + offset, start_remaining, sep, quote, '\n', options.escape_backslash,
+                      comment_char);
 
     const char* field_data;
     size_t field_len;
@@ -225,9 +230,20 @@ std::pair<size_t, bool> parse_chunk_with_state(
         }
       }
 
-      // Inline comment detection: check for comment string in unquoted fields
-      // or after closing quote in quoted fields
-      if (!options.comment.empty()) {
+      // Check if SplitFields detected a comment boundary (single-char fast path)
+      if (iter.hit_comment()) {
+        // Re-trim trailing whitespace from the truncated field
+        if (options.trim_ws) {
+          while (field_len > 0 && (field_data[field_len - 1] == ' ' || field_data[field_len - 1] == '\t')) {
+            field_len--;
+          }
+        }
+        inline_comment_found = true;
+      }
+
+      // Multi-char inline comment detection: check for comment string in unquoted fields
+      // or after closing quote in quoted fields (only for multi-char comments)
+      if (has_multi_char_comment) {
         const std::string& cmt = options.comment;
         if (!needs_escaping) {
           // Unquoted field: search for comment string within the raw field
@@ -377,6 +393,20 @@ std::pair<size_t, bool> parse_chunk_with_state(
     row_count++;
     // Advance offset by consumed bytes
     offset += start_remaining - iter.remaining();
+
+    // When SplitFields stopped at a comment char, skip past the remaining
+    // comment text to the actual end-of-line.
+    if (iter.hit_comment()) {
+      while (offset < size && data[offset] != '\n' && data[offset] != '\r') {
+        offset++;
+      }
+      if (offset < size && data[offset] == '\r') {
+        offset++;
+        if (offset < size && data[offset] == '\n') offset++;
+      } else if (offset < size && data[offset] == '\n') {
+        offset++;
+      }
+    }
   }
 
 done_chunk: // Early exit target for should_stop() (FAIL_FAST error mode)
@@ -1458,6 +1488,10 @@ Result<ParsedChunks> CsvReader::read_all_serial() {
   const std::string_view sep = options.separator;
   const size_t num_cols = columns.size();
   const bool check_errors = impl_->error_collector.is_enabled();
+  // For single-char comments, pass to SplitFields for SIMD-accelerated detection.
+  // Multi-char comments still use the scalar post-field scan below.
+  const char comment_char = (options.comment.size() == 1) ? options.comment[0] : '\0';
+  const bool has_multi_char_comment = options.comment.size() > 1;
   // Row number is 1-indexed; row 1 is the header (if present)
   size_t row_number = impl_->options.has_header ? 2 : 1;
 
@@ -1508,7 +1542,8 @@ Result<ParsedChunks> CsvReader::read_all_serial() {
     // Create iterator for remaining data - it stops at EOL
     size_t row_start_offset = offset;
     size_t start_remaining = size - offset;
-    SplitFields iter(data + offset, start_remaining, sep, quote, '\n', options.escape_backslash);
+    SplitFields iter(data + offset, start_remaining, sep, quote, '\n', options.escape_backslash,
+                      comment_char);
 
     const char* field_data;
     size_t field_len;
@@ -1533,9 +1568,20 @@ Result<ParsedChunks> CsvReader::read_all_serial() {
         }
       }
 
-      // Inline comment detection: check for comment string in unquoted fields
-      // or after closing quote in quoted fields
-      if (!impl_->options.comment.empty()) {
+      // Check if SplitFields detected a comment boundary (single-char fast path)
+      if (iter.hit_comment()) {
+        // Re-trim trailing whitespace from the truncated field
+        if (options.trim_ws) {
+          while (field_len > 0 && (field_data[field_len - 1] == ' ' || field_data[field_len - 1] == '\t')) {
+            field_len--;
+          }
+        }
+        inline_comment_found = true;
+      }
+
+      // Multi-char inline comment detection: check for comment string in unquoted fields
+      // or after closing quote in quoted fields (only for multi-char comments)
+      if (has_multi_char_comment) {
         const std::string& cmt = impl_->options.comment;
         if (!needs_escaping) {
           // Unquoted field: search for comment string within the raw field
@@ -1681,6 +1727,20 @@ Result<ParsedChunks> CsvReader::read_all_serial() {
 
     // Advance offset by consumed bytes
     offset += start_remaining - iter.remaining();
+
+    // When SplitFields stopped at a comment char, skip past the remaining
+    // comment text to the actual end-of-line.
+    if (iter.hit_comment()) {
+      while (offset < size && data[offset] != '\n' && data[offset] != '\r') {
+        offset++;
+      }
+      if (offset < size && data[offset] == '\r') {
+        offset++;
+        if (offset < size && data[offset] == '\n') offset++;
+      } else if (offset < size && data[offset] == '\n') {
+        offset++;
+      }
+    }
 
     // Unclosed quote detection: if the iterator finished inside a quote
     // on the very last row (no more data), report it after the main loop

--- a/tests/testthat/test-libvroom.R
+++ b/tests/testthat/test-libvroom.R
@@ -504,6 +504,41 @@ test_that("libvroom handles skip combined with comment", {
   )
 })
 
+test_that("libvroom handles inline comments via SIMD detection", {
+  # Inline comment in unquoted field
+  test_libvroom(
+    "a,b\n1#comment,2\n3,4\n",
+    delim = ",",
+    comment = "#",
+    equals = tibble::tibble(a = c(1, 3), b = c(NA, 4))
+  )
+
+  # Comment after quoted field
+  test_libvroom(
+    "a,b\n\"val\"#comment,2\n",
+    delim = ",",
+    comment = "#",
+    equals = tibble::tibble(a = "val", b = NA_character_)
+  )
+
+  # Hash inside quoted field is preserved (not treated as comment)
+  test_libvroom(
+    "a,b\n\"val#ue\",2\n",
+    delim = ",",
+    comment = "#",
+    equals = tibble::tibble(a = "val#ue", b = 2L)
+  )
+
+  # Mixed full-line and inline comments
+  # In "1,2#inline": field b is "2" (comment truncates after the value)
+  test_libvroom(
+    "a,b\n# full line\n1,2#inline\n3,4\n",
+    delim = ",",
+    comment = "#",
+    equals = tibble::tibble(a = c(1, 3), b = c(2, 4))
+  )
+})
+
 test_that("libvroom handles n_max parameter", {
   test_libvroom(
     "a,b,c\n1,2,3\n4,5,6\n7,8,9\n",


### PR DESCRIPTION
## Summary

- For single-char comments (the common case, e.g., `"#"`), the comment character is now OR'd into the SIMD boundary masks in `SplitFields`, eliminating the per-field scalar `memcmp` scan
- This gives zero extra cost for comment detection during the hot parsing loop — the comment char is found in the same SIMD pass that finds separators and EOL characters
- Multi-char comments continue to use the existing scalar detection path
- `SplitFields::hit_comment()` flag tells `csv_reader.cpp` to skip to the actual EOL after the comment

### Key changes

| File | Change |
|------|--------|
| `split_fields.h` | Add `comment_char_` member, `hit_comment()` accessor; `scan_unquoted_field()` uses `scan_for_three_chars`; `scan_quoted_field()` ORs comment into end_mask; `next()` detects comment at boundary |
| `csv_reader.cpp` | Pass `comment_char` to `SplitFields`; skip-to-EOL after `hit_comment()`; keep scalar path for multi-char comments only |
| `test-libvroom.R` | Tests for inline comments: unquoted fields, after quoted fields, hash inside quotes (preserved), mixed full-line + inline |

## Test plan

- [x] Inline comment in unquoted field truncates correctly (`1#comment` → `1`)
- [x] Comment after quoted field works (`"val"#comment` → `val`)
- [x] Hash inside quotes is preserved (`"val#ue"` → `val#ue`)
- [x] Mixed full-line and inline comments work together
- [x] Full test suite passes: FAIL 0 | WARN 10 | SKIP 14 | PASS 1042