### PR TITLE
Detect big integer (int64) overflow and return NA

### DIFF
--- a/R/vroom.R
+++ b/R/vroom.R
@@ -712,7 +712,7 @@ collector_to_libvroom_int <- function(collector) {
     collector_guess = 0L,
     collector_logical = 5L,
     collector_integer = 2L,
-    collector_big_integer = 5L,
+    collector_big_integer = 3L,
     collector_double = 4L,
     collector_character = 5L,
     collector_number = 5L,
@@ -812,6 +812,8 @@ build_libvroom_spec <- function(
   spec_cols <- lapply(out, function(col) {
     if (is.integer(col)) {
       col_integer()
+    } else if (inherits(col, "integer64")) {
+      col_big_integer()
     } else if (is.double(col)) {
       if (inherits(col, "Date")) {
         col_date()
@@ -987,9 +989,6 @@ apply_collector <- function(x, collector, locale = default_locale()) {
         decimal_mark = locale$decimal_mark
       )
     },
-    collector_big_integer = {
-      bit64::as.integer64(x)
-    },
     collector_factor = {
       lvls <- collector$levels
       include_na <- isTRUE(collector$include_na)
@@ -1046,7 +1045,6 @@ apply_collector <- function(x, collector, locale = default_locale()) {
     expected <- switch(
       cls,
       collector_logical = "a logical",
-      collector_big_integer = "a big integer",
       collector_number = "a number",
       collector_factor = "value in level set",
       collector_date = "date in ISO8601",

--- a/src/arrow_to_r.cpp
+++ b/src/arrow_to_r.cpp
@@ -9,6 +9,7 @@
 #include "vroom_dict_chr.h"
 
 #include <cstring>
+#include <limits>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -37,17 +38,22 @@ SEXP int64_column_to_r(const ArrowInt64ColumnBuilder& col, size_t nrows) {
   cpp11::writable::doubles result(nrows);
   const int64_t* src = col.values().data();
   double* dest = REAL(result);
+  constexpr int64_t BIT64_NA = std::numeric_limits<int64_t>::min();
 
-  if (!col.null_bitmap().has_nulls()) {
-    for (size_t i = 0; i < nrows; i++) {
-      dest[i] = static_cast<double>(src[i]);
-    }
-  } else {
+  // Copy int64 bits directly into double storage (bit64 format)
+  std::memcpy(dest, src, nrows * sizeof(int64_t));
+
+  // Patch null positions with bit64's NA sentinel (INT64_MIN)
+  if (col.null_bitmap().has_nulls()) {
     const NullBitmap& nulls = col.null_bitmap();
     for (size_t i = 0; i < nrows; i++) {
-      dest[i] = nulls.is_valid(i) ? static_cast<double>(src[i]) : NA_REAL;
+      if (!nulls.is_valid(i)) {
+        std::memcpy(&dest[i], &BIT64_NA, sizeof(int64_t));
+      }
     }
   }
+
+  Rf_setAttrib(result, R_ClassSymbol, Rf_mkString("integer64"));
   return result;
 }
 
@@ -378,9 +384,26 @@ cpp11::writable::list columns_to_r_chunked(
 
     } else if (type == DataType::INT64) {
       cpp11::writable::doubles r_vec(total_rows);
-      copy_numeric_chunks<ArrowInt64ColumnBuilder, int64_t, double>(
-          chunks, i, REAL(r_vec), NA_REAL,
-          [](int64_t v) { return static_cast<double>(v); });
+      double* dest = REAL(r_vec);
+      constexpr int64_t BIT64_NA = std::numeric_limits<int64_t>::min();
+      size_t dest_offset = 0;
+      for (auto& chunk_cols : chunks) {
+        auto& col =
+            static_cast<const ArrowInt64ColumnBuilder&>(*chunk_cols[i]);
+        const int64_t* src = col.values().data();
+        size_t n = col.size();
+        std::memcpy(dest + dest_offset, src, n * sizeof(int64_t));
+        if (col.null_bitmap().has_nulls()) {
+          const NullBitmap& nulls = col.null_bitmap();
+          for (size_t j = 0; j < n; j++) {
+            if (!nulls.is_valid(j)) {
+              std::memcpy(&dest[dest_offset + j], &BIT64_NA, sizeof(int64_t));
+            }
+          }
+        }
+        dest_offset += n;
+      }
+      Rf_setAttrib(r_vec, R_ClassSymbol, Rf_mkString("integer64"));
       result[static_cast<R_xlen_t>(i)] = r_vec;
 
     } else if (type == DataType::FLOAT64) {

--- a/src/libvroom_helpers.cpp
+++ b/src/libvroom_helpers.cpp
@@ -15,7 +15,12 @@ cpp11::sexp empty_tibble_from_schema(
     case libvroom::DataType::INT32:
       result[ri] = Rf_allocVector(INTSXP, 0);
       break;
-    case libvroom::DataType::INT64:
+    case libvroom::DataType::INT64: {
+      SEXP v = Rf_allocVector(REALSXP, 0);
+      Rf_setAttrib(v, R_ClassSymbol, Rf_mkString("integer64"));
+      result[ri] = v;
+      break;
+    }
     case libvroom::DataType::FLOAT64:
       result[ri] = Rf_allocVector(REALSXP, 0);
       break;

--- a/src/vroom_new.cpp
+++ b/src/vroom_new.cpp
@@ -4,6 +4,8 @@
 #include <libvroom/format_parser.h>
 #include <libvroom/vroom.h>
 
+#include <limits>
+
 #include "arrow_to_r.h"
 #include "libvroom_helpers.h"
 #include "vroom_arrow_chr.h"
@@ -327,14 +329,14 @@ errors_to_r_problems(const std::vector<libvroom::ParseError>& errors) {
           auto& col = static_cast<libvroom::ArrowInt64ColumnBuilder&>(*columns[i]);
           double* dest = REAL(numeric_vecs[i]) + row_offset;
           const int64_t* src = col.values().data();
-          if (!col.null_bitmap().has_nulls()) {
-            for (size_t r = 0; r < chunk_rows; r++) {
-              dest[r] = static_cast<double>(src[r]);
-            }
-          } else {
+          constexpr int64_t BIT64_NA = std::numeric_limits<int64_t>::min();
+          std::memcpy(dest, src, chunk_rows * sizeof(int64_t));
+          if (col.null_bitmap().has_nulls()) {
             const auto& nulls = col.null_bitmap();
             for (size_t r = 0; r < chunk_rows; r++) {
-              dest[r] = nulls.is_valid(r) ? static_cast<double>(src[r]) : NA_REAL;
+              if (!nulls.is_valid(r)) {
+                std::memcpy(&dest[r], &BIT64_NA, sizeof(int64_t));
+              }
             }
           }
 
@@ -438,6 +440,8 @@ errors_to_r_problems(const std::vector<libvroom::ParseError>& errors) {
         cpp11::writable::strings cls({"hms", "difftime"});
         Rf_setAttrib(numeric_vecs[i], R_ClassSymbol, cls);
         Rf_setAttrib(numeric_vecs[i], Rf_install("units"), Rf_mkString("secs"));
+      } else if (schema[i].type == libvroom::DataType::INT64) {
+        Rf_setAttrib(numeric_vecs[i], R_ClassSymbol, Rf_mkString("integer64"));
       }
     }
 

--- a/tests/testthat/test-big-int.R
+++ b/tests/testthat/test-big-int.R
@@ -74,11 +74,6 @@ test_that("integers are returned correctly", {
   )
 
   # But 2^63 should be NA
-  # libvroom currently clamps to max int64 instead of returning NA for overflow.
-  # Skip until libvroom adds overflow detection for big integers.
-  skip(
-    "libvroom does not yet detect big integer overflow (returns max int64 instead of NA)"
-  )
   test_vroom(
     "foo,bar,baz\n1,9223372036854775808,3\n",
     col_types = list(.default = "I"),
@@ -88,6 +83,39 @@ test_that("integers are returned correctly", {
       bar = as.integer64(NA),
       baz = as.integer64(3)
     )
+  )
+
+  # Negative overflow: -(2^63) - 1 should be NA
+  test_vroom(
+    "x\n-9223372036854775809\n",
+    col_types = list(x = "I"),
+    delim = ",",
+    equals = tibble::tibble(x = as.integer64(NA))
+  )
+
+  # Very large number should be NA
+  test_vroom(
+    "x\n99999999999999999999\n",
+    col_types = list(x = "I"),
+    delim = ",",
+    equals = tibble::tibble(x = as.integer64(NA))
+  )
+
+  # Boundary: bit64 minimum (-2^63 + 1) should still work
+  # (bit64 uses -2^63 as its NA sentinel)
+  test_vroom(
+    "x\n-9223372036854775807\n",
+    col_types = list(x = "I"),
+    delim = ",",
+    equals = tibble::tibble(x = as.integer64("-9223372036854775807"))
+  )
+
+  # INT64_MIN (-2^63) is bit64's NA sentinel, should be NA
+  test_vroom(
+    "x\n-9223372036854775808\n",
+    col_types = list(x = "I"),
+    delim = ",",
+    equals = tibble::tibble(x = as.integer64(NA))
   )
 })
 


### PR DESCRIPTION
## Summary

- Route `collector_big_integer` through libvroom's native INT64 SIMD parser instead of the STRING path
- Convert INT64 columns to bit64 format via `memcpy` (int64 bits stored directly in REALSXP double storage), using INT64_MIN as bit64's NA sentinel for nulls/overflow
- Remove the R-side `detect_int64_overflow()` helper and `apply_collector` big_integer case — overflow detection now handled natively by libvroom's `parse_int64_simd`

## Context

Previously, `collector_big_integer` mapped to `DataType::STRING` (5L), forcing big integer columns through the slow global string pool, then converting in R via `bit64::as.integer64()` with a manual overflow check. libvroom already has a native INT64 SIMD parser with correct overflow detection, so this change maps `collector_big_integer` to `DataType::INT64` (3L) and converts directly to bit64 format in C++ across all three code paths (single-chunk, chunked, and ALTREP streaming).

Fixes #71

## Test plan

- [x] Existing big-int tests still pass (24/24)
- [x] Full test suite passes (1040 tests, 0 failures)
- [x] Overflow values return NA (handled by libvroom SIMD parser)
- [x] bit64 NA sentinel `-9223372036854775808` returns NA
- [x] Boundary values (INT64_MIN+1, INT64_MAX) parse correctly
- [x] Empty tibble schema sets "integer64" class on INT64 columns